### PR TITLE
Remove unneeded apostrophes in grafana_datasources

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,8 +142,8 @@ grafana_datasources: []
 #    type: "prometheus"
 #    access: "proxy"
 #    url: "http://prometheus.mydomain"
-#    basicAuth: "true"
+#    basicAuth: true
 #    basicAuthUser: "admin"
 #    basicAuthPassword: "password"
-#    isDefault: "true"
+#    isDefault: true
 #    jsonData: '{"tlsAuth":false,"tlsAuthWithCACert":false,"tlsSkipVerify":true}'

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -17,7 +17,7 @@
 
 - name: Check if all variables in datasources definition have their correct type
   fail:
-    msg: "Boolean variables in grafana_datasources shouldn't be passed as strings. Please remove unneded apostrophes."
+    msg: "Boolean variables in grafana_datasources shouldn't be passed as strings. Please remove unneeded apostrophes."
   when: ( item.isDefault is defined and item.isDefault is string ) or
         ( item.basicAuth is defined and item.basicAuth is string )
   with_items: "{{ grafana_datasources }}"


### PR DESCRIPTION
After uncommenting the example values for `grafana_datasources` it made the task fail in Ansible. The message being thrown is:

> "Boolean variables in grafana_datasources shouldn't be passed as strings. Please remove unneded apostrophes."

After removing the apostrophes, the task ran successfully.
By the way, this PR will fix the typo in the message too.