### PR TITLE
More operating systems and cleanup

### DIFF
--- a/.travis/images.sh
+++ b/.travis/images.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for i in ubuntu-molecule:16.04 debian-molecule:9 debian-molecule:8 centos-molecule:7 fedora-molecule:27
+do 
+    docker pull paulfantom/$i &
+done
+
+wait

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-grafana_system_user: grafana
-grafana_system_group: grafana
-
 grafana_version: 4.6.3
 
 grafana_instance: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,12 +11,20 @@ galaxy_info:
   - name: Debian
     versions:
     - jessie
+    - stretch
   - name: EL
     versions:
     - 7
+  - name: Fedora
+    versions:
+    - 27
   galaxy_tags:
   - grafana
   - dashboard
+  - alerts
+  - alerting
+  - presentation
+  - monitoring
   - metrics
 
 dependencies: []

--- a/molecule.yml
+++ b/molecule.yml
@@ -5,17 +5,40 @@ driver:
   name: docker
 verifier:
   name: testinfra
+dependency:
+  name: shell
+  command: ./.travis/images.sh
 docker:
+  build_image: False
   containers:
     - name: xenial
-      image: solita/ubuntu-systemd
+      image: paulfantom/ubuntu-molecule
       image_version: 16.04
       privileged: true
-    - name: debian-jessie
-      image: jrei/systemd-debian
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: stretch
+      image: paulfantom/debian-molecule
+      image_version: 9
+      cap_add: SYS_ADMIN
+      privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: jessie
+      image: paulfantom/debian-molecule
       image_version: 8
       privileged: true
-    - name: centos
-      image: centos/systemd
-      image_version: latest
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: centos7
+      image: paulfantom/centos-molecule
+      image_version: 7
       privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    - name: fedora
+#      image: paulfantom/fedora-molecule
+#      image_version: 27
+#      privileged: true
+#      volume_mounts:
+#        - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,8 +22,8 @@
     path: "{{ item }}"
     state: directory
     mode: 0755
-    owner: "{{ grafana_system_user }}"
-    group: "{{ grafana_system_group }}"
+    owner: "grafana"
+    group: "grafana"
   with_items:
     - "{{ grafana_logs_dir }}"
     - "{{ grafana_data_dir }}"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,28 +1,28 @@
-- name: Check if system architecture is supported
+- name: Fail on unsupported system architectures
   fail:
     msg: "Sorry grafana doesn't support {{ ansible_architecture }} on this OS family ({{ ansible_os_family }}). Exiting."
   when:
   - ansible_architecture != "x86_64"
   - not ( ansible_architecture in ['armv6l', 'armv7l'] and ansible_os_family == 'Debian' )
 
-- name: Check if datasources are configured when dashboards are set to be installed
+- name: Fail when datasources aren't configured when dashboards are set to be installed
   fail:
     msg: "You need to specify datasources for dashboards!!!"
   when: grafana_dashboards != [] and grafana_datasources == []
 
-- name: Check if grafana admin password is set
+- name: Fail when grafana admin password isn't set
   fail:
     msg: "Please specify grafana admin password (grafana_security.admin_password)"
   when: grafana_security.admin_password == ''
 
-- name: Check if all variables in datasources definition have their correct type
+- name: Fail on incorrect variable types in datasource definitions
   fail:
     msg: "Boolean variables in grafana_datasources shouldn't be passed as strings. Please remove unneeded apostrophes."
   when: ( item.isDefault is defined and item.isDefault is string ) or
         ( item.basicAuth is defined and item.basicAuth is string )
   with_items: "{{ grafana_datasources }}"
 
-- name: Check database configuration
+- name: Fail on bad database configuration
   fail:
     msg: "Wrong database configuration. Please look at http://docs.grafana.org/installation/configuration/#database"
   when: ( grafana_database.type == "sqlite3" and grafana_database.url is defined ) or
@@ -32,7 +32,7 @@
         ( grafana_database.type == "sqlite3" and grafana_database.password is defined ) or
         ( grafana_database.type == "sqlite3" and grafana_database.server_cert_name is defined )
 
-- name: Check grafana domain configuration
+- name: Fail when grafana domain isn't properly configured
   fail:
     msg: "Check server configuration. Please look at http://docs.grafana.org/installation/configuration/#server"
   when:

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,46 +1,8 @@
 ---
 - hosts: all
-  tasks:
-    - name: install testing suite
-      package:
-        name: "{{ item }}"
-        state: present
-      with_items:
-        - iproute
-        - net-tools
-
-- hosts: all
   any_errors_fatal: yes
+  pre_tasks:
+    - name: Include vars
+      include_vars: vars.yml
   roles:
     - ansible-grafana
-  vars:
-    grafana_security:
-      admin_user: admin
-      admin_password: "password"
-    grafana_address: "127.0.0.1"
-    grafana_auth:
-      disable_login_form: false
-      disable_signout_menu: false
-      anonymous:
-        org_name: "Main Organization"
-        org_role: Viewer
-      basic: True
-    grafana_plugins:
-      - raintank-worldping-app
-    grafana_dashboards:
-      - dashboard_id: '1860'
-        revision_id: '4'
-        datasource: 'Prometheus'
-      - dashboard_id: '358'
-        revision_id: '1'
-        datasource: 'Prometheus'
-    grafana_datasources:
-      - name: "Prometheus"
-        type: "prometheus"
-        access: "proxy"
-        url: "http://prometheus.mydomain"
-        basicAuth: true
-        basicAuthUser: "admin"
-        basicAuthPassword: "password"
-        isDefault: true
-        jsonData: '{"tlsAuth":false,"tlsAuthWithCACert":false,"tlsSkipVerify":true}'

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -4,7 +4,7 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 
 def test_directories(host):
-    present = [
+    dirs = [
         "/etc/grafana",
         "/var/log/grafana",
         "/var/lib/grafana",
@@ -12,49 +12,30 @@ def test_directories(host):
         "/var/lib/grafana/plugins",
         "/var/lib/grafana/plugins/raintank-worldping-app"
     ]
-    if present:
-        for directory in present:
-            d = host.file(directory)
-            assert d.is_directory
-            assert d.exists
-
-
-def test_files(host):
-    present = [
+    files = [
         "/etc/grafana/grafana.ini"
     ]
-    if present:
-        for file in present:
-            f = host.file(file)
-            assert f.exists
-            assert f.is_file
+    for directory in dirs:
+        d = host.file(directory)
+        assert d.is_directory
+        assert d.exists
+    for file in files:
+        f = host.file(file)
+        assert f.exists
+        assert f.is_file
 
 
 def test_service(host):
-    present = [
-        "grafana-server"
-    ]
-    if present:
-        for service in present:
-            s = host.service(service)
-            assert s.is_enabled
+    s = host.service("grafana-server")
+    assert s.is_enabled
+    assert s.is_running
 
 
 def test_packages(host):
-    present = [
-        "grafana"
-    ]
-    if present:
-        for package in present:
-            p = host.package(package)
-            assert p.is_installed
+    p = host.package("grafana")
+    assert p.is_installed
+    assert p.version == "4.6.3"
 
 
 def test_socket(host):
-    present = [
-        # "tcp://0.0.0.0:3000"
-        "tcp://127.0.0.1:3000"
-    ]
-    for socket in present:
-        s = host.socket(socket)
-        assert s.is_listening
+    assert host.socket("tcp://127.0.0.1:3000").is_listening

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,0 +1,30 @@
+grafana_security:
+  admin_user: admin
+  admin_password: "password"
+grafana_address: "127.0.0.1"
+grafana_auth:
+  disable_login_form: false
+  disable_signout_menu: false
+  anonymous:
+    org_name: "Main Organization"
+    org_role: Viewer
+  basic: True
+grafana_plugins:
+  - raintank-worldping-app
+grafana_dashboards:
+  - dashboard_id: '1860'
+    revision_id: '4'
+    datasource: 'Prometheus'
+  - dashboard_id: '358'
+    revision_id: '1'
+    datasource: 'Prometheus'
+grafana_datasources:
+  - name: "Prometheus"
+    type: "prometheus"
+    access: "proxy"
+    url: "http://prometheus.mydomain"
+    basicAuth: true
+    basicAuthUser: "admin"
+    basicAuthPassword: "password"
+    isDefault: true
+    jsonData: '{"tlsAuth":false,"tlsAuthWithCACert":false,"tlsSkipVerify":true}'


### PR DESCRIPTION
- Added support for tests in debian 9 with custom docker images.
- Removed unneeded variables `grafana_system_user` and `grafana_system_group`, they were confusing since grafana creates user and group while installing from repository provided package
- simplified tests and added check for running service and grafana version
- moved playbook variables to another file
- changed tasks names in prefight.yml