### PR TITLE
Make Grafana-server restart with sudo privileges.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: restart grafana
+  become: true
   service:
     name: grafana-server
     state: restarted


### PR DESCRIPTION
I'm trying to include the `cloudalchemy.grafana` role from our own monitoring role like this:
```
- name: Deploy Grafana
  become: true
  when: act_as_grafana_server == true
  include_role:
    name: cloudalchemy.grafana # https://github.com/cloudalchemy/ansible-grafana
  vars:
    grafana_address: "0.0.0.0"
    [...]
```

This results in a fatal error, at the point when running the handler that should restart grafana:
```
RUNNING HANDLER [cloudalchemy.grafana : restart grafana] ****************************************************************************************************************************
fatal: [monitor]: FAILED! => {"changed": false, "msg": "Unable to start service grafana-server: Failed to start grafana-server.service: Interactive authentication required.\nSee system logs and 'systemctl status grafana-server.service' for details.\n"}
```

The service could only be restarted with sudo-privileges, which in the case of an `include_role` or `import_role` won't get picked up correctly by the handler responsible for the service-restart.
This PR will make sure that the `grafana-server.service` will be restarted with the correct privileges.