### PR TITLE
Add Ubuntu Bionic support/testing

### DIFF
--- a/.travis/images.sh
+++ b/.travis/images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-for i in ubuntu-molecule:16.04 debian-molecule:9 debian-molecule:8 centos-molecule:7 fedora-molecule:27
-do 
+for i in ubuntu-molecule:16.04 ubuntu-molecule:18.04 debian-molecule:9 debian-molecule:8 centos-molecule:7 fedora-molecule:27
+do
     docker pull paulfantom/$i &
 done
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We provide demo site for full monitoring solution based on prometheus and grafan
 The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/metacloud/molecule) (v1.25). You will have to install Docker on your system. See Get started for a Docker package suitable to for your system.
 All packages you need to can be specified in one line:
 ```sh
-pip install ansible ansible-lint>=3.4.15 molecule==1.25.0 docker testinfra>=1.7.0
+pip install ansible 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker 'testinfra>=1.7.0,<=1.10.1'
 ```
 This should be similiar to one listed in `.travis.yml` file in `install` section. 
 After installing test suit you can run test by running

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - xenial
+    - bionic
   - name: Debian
     versions:
     - jessie

--- a/molecule.yml
+++ b/molecule.yml
@@ -17,6 +17,12 @@ docker:
       privileged: true
       volume_mounts:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: bionic
+      image: paulfantom/ubuntu-molecule
+      image_version: 18.04
+      privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
     - name: stretch
       image: paulfantom/debian-molecule
       image_version: 9

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -3,4 +3,5 @@ grafana_package: "grafana={{ grafana_version }}"
 grafana_dependencies:
   - apt-transport-https
   - adduser
+  - ca-certificates
   - libfontconfig


### PR DESCRIPTION
In order to support and to validate support for
Ubuntu 18.04 (Bionic), we add the appropriate
molecule configuration to test it, along with
the only change necessary for the tests to pass.