### PR TITLE
travis: Automatically use the latest Ansible patch releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE=2.2.3
-  - ANSIBLE=2.3.3
-  - ANSIBLE=2.4.3
+  - ANSIBLE='ansible>=2.2.0,<2.3.0'
+  - ANSIBLE='ansible>=2.3.0,<2.4.0'
+  - ANSIBLE='ansible>=2.4.0,<2.5.0'
 install:
-  - pip install ansible==${ANSIBLE} ansible-lint>=3.4.15 molecule==1.25.0 docker git-semver 'testinfra>=1.7.0,<=1.10.1'
+  - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker git-semver 'testinfra>=1.7.0,<=1.10.1'
 script:
   - molecule test
 deploy:


### PR DESCRIPTION
When a new patch version of Ansible is released, currently the
travis configuration needs to be updated to consume it for tests.

This patch implements a change in the configuration to ensure that
the latest patch release for each minor series tested is always used.