### PR TITLE
vars: Handle the use of grafana_version='latest' properly

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,5 +1,5 @@
 ---
-grafana_package: "grafana={{ grafana_version }}"
+grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('=' ~ grafana_version, '') }}"
 grafana_dependencies:
   - apt-transport-https
   - adduser

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,3 @@
 ---
-grafana_package: "grafana-{{ grafana_version }}"
+grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"
 grafana_dependencies: []


### PR DESCRIPTION
When grafana_version='latest', the package handlers do not
know what to do with the package name given to them, and
the task fails.

This patch implements a ternary check in the vars to ensure
that if that value is given, the version is omitted from
the package name given to the task which installs it.