### PR TITLE
datasources: Allow additional datasources to be created later

### DIFF
--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -19,7 +19,7 @@
     body: "{{ item | to_json }}"
   with_items: "{{ grafana_datasources }}"
   no_log: True
-  when: datasources.content == "[]"
+  when: ((datasources['json'] | selectattr("name", "equalto", item['name'])) | list) | length == 0
 
 - name: Create datasources file
   copy:


### PR DESCRIPTION
Currently the role only allows the datasources to be configured
on the first implementation. From then on if there are any data
sources configured, the task to upload any new configuration is
ignored.

This patch implements a validation for each datasource item to
check whether it's already configured using the name as the key.
If the item is not configured, it will configure it.