### PR TITLE
Add ability to generate API keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,3 +148,15 @@ grafana_datasources: []
 #    basicAuthPassword: "password"
 #    isDefault: true
 #    jsonData: '{"tlsAuth":false,"tlsAuthWithCACert":false,"tlsSkipVerify":true}'
+
+# API keys to configure
+grafana_api_keys: []
+#  - name: "admin"
+#    role: "Admin"
+#  - name: "viewer"
+#    role: "Viewer"
+#  - name: "editor"
+#    role: "Editor"
+
+# The location where the keys should be stored.
+grafana_api_keys_dir: "{{ lookup('env', 'HOME') }}/grafana/keys"

--- a/tasks/api_keys.yml
+++ b/tasks/api_keys.yml
@@ -1,0 +1,40 @@
+- name: Ensure grafana key directory exists
+  become: no
+  file:
+    path: "{{ grafana_api_keys_dir }}/{{ inventory_hostname }}"
+    state: directory
+  delegate_to: localhost
+
+- name: Check api key list
+  uri:
+    url: "{{ grafana_url }}/api/auth/keys"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: yes
+    return_content: yes
+  no_log: True
+  register: existing_api_keys
+
+- name: Create grafana api keys
+  uri:
+    url: "{{ grafana_url }}/api/auth/keys"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: yes
+    method: POST
+    body_format: json
+    body: "{{ item | to_json }}"
+  with_items: "{{ grafana_api_keys }}"
+  no_log: True
+  when: ((existing_api_keys['json'] | selectattr("name", "equalto", item['name'])) | list) | length == 0
+  register: new_api_keys
+
+- name: Create api keys file to allow the keys to be seen and used by other automation
+  become: no
+  copy:
+    dest: "{{ grafana_api_keys_dir }}/{{ inventory_hostname }}/{{ item['item']['name'] }}.key"
+    content: "{{ item['json']['key'] }}"
+    backup: no
+  when: item['json'] is defined
+  with_items: "{{ new_api_keys['results'] }}"
+  delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,9 @@
     host: "{{ grafana_address }}"
     port: "{{ grafana_port }}"
 
+- include: api_keys.yml
+  when: grafana_api_keys | length > 0
+
 - include: datasources.yml
   when: grafana_datasources != []
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -38,3 +38,10 @@
   when:
   - grafana_server.root_url is defined
   - grafana_server.root_url | search(grafana_server.domain)
+
+- name: Fail when grafana_api_keys uses invalid role names
+  fail:
+    msg: "Check grafana_api_keys. The role can only be one of the following values: Viewer, Editor or Admin."
+  when:
+    - item.role not in ['Viewer', 'Editor', 'Admin']
+  with_items: "{{ grafana_api_keys }}"

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -10,6 +10,14 @@ grafana_auth:
     org_name: "Main Organization"
     org_role: Viewer
   basic: True
+grafana_api_keys:
+  - name: "admin"
+    role: "Admin"
+  - name: "viewer"
+    role: "Viewer"
+  - name: "editor"
+    role: "Editor"
+grafana_api_keys_dir: "/tmp/grafana/keys"
 grafana_plugins:
   - raintank-worldping-app
 grafana_dashboards:


### PR DESCRIPTION
This patch adds the ability to generate API keys
which can be used in automation later in the
same playbook, or by entirely different playbooks.
Given that the API keys are generated once-off
and not retrievable after the fact, we store the
keys on the deployment host to allow retrieval
and re-use.