### PR TITLE
add ability to define notification channels

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,6 +140,14 @@ grafana_dashboards: []
 #    revision_id: '1'
 #    datasource: 'Prometheus'
 
+# Alert notification channels to configure
+grafana_alert_notifications: []
+#   - name: "Email Alert"
+#     type: "email"
+#     isDefault: true
+#     settings:
+#       addresses: "example@example.com"
+
 # Datasources to configure
 grafana_datasources: []
 #  - name: "Prometheus"

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -26,6 +26,12 @@
     grafana_api_keys_dir: "/tmp/grafana/keys"
     grafana_plugins:
       - raintank-worldping-app
+    grafana_alert_notifications:
+      - name: "Email Alert"
+        type: "email"
+        isDefault: true
+        settings:
+          addresses: "example@example.com"
     grafana_dashboards:
       - dashboard_id: '1860'
         revision_id: '4'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,5 +33,8 @@
 - include: datasources.yml
   when: grafana_datasources != []
 
+- include: notifications.yml
+  when: grafana_alert_notifications | length > 0
+
 - include: dashboards.yml
   when: grafana_dashboards | length > 0

--- a/tasks/notifications.yml
+++ b/tasks/notifications.yml
@@ -1,0 +1,23 @@
+---
+- name: Check alert notifications list
+  uri:
+    url: "{{ grafana_url }}/api/alert-notifications"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    return_content: true
+  no_log: true
+  register: alert_notifications
+
+- name: Create grafana alert notification channels
+  uri:
+    url: "{{ grafana_url }}/api/alert-notifications"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: POST
+    body_format: json
+    body: "{{ item | to_json }}"
+  with_items: "{{ grafana_alert_notifications }}"
+  no_log: true
+  when: ((alert_notifications['json'] | selectattr("name", "equalto", item['name'])) | list) | length == 0


### PR DESCRIPTION
I've only tested this with my setup and an email alert, but it should be fine with other kinds.

[Notifications API](http://docs.grafana.org/http_api/alerting/#get-alert-notifications)