### PR TITLE
Add LDAP configuration tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_welcome_email_on_sign_up` | False | Send welcome email after signing up |
 | `grafana_users` | { allow_sign_up: False, auto_assign_org_role: Viewer, default_theme: dark } | [users](http://docs.grafana.org/installation/configuration/#users) configuration section |
 | `grafana_auth` | {} | [authorization](http://docs.grafana.org/installation/configuration/#auth) configuration section |
+| `grafana_ldap` | {} | [ldap](http://docs.grafana.org/installation/ldap/) configuration section. group_mappings are expanded, see defaults for example |
 | `grafana_session` | {} | [session](http://docs.grafana.org/installation/configuration/#session) management configuration section |
 | `grafana_analytics` | {} | Google [analytics](http://docs.grafana.org/installation/configuration/#analytics) configuration section |
 | `grafana_smtp` | {} | [smtp](http://docs.grafana.org/installation/configuration/#smtp) configuration section |

--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_port` | 3000 | port on which grafana listens |
 | `grafana_url` | "http://{{ grafana_address }}:{{ grafana_port }}" | Full URL used to access Grafana from a web browser |
 | `grafana_domain` | "{{ ansible_fqdn \| default(ansible_host) \| default('localhost') }}" | setting is only used in as a part of the `root_url` option. Useful when using GitHub or Google OAuth |
-| `grafana_server` | { protocol: http, enforce_domain: false, socket: "", cert_key: "", cert_file: "", enable_gzip: False, static_root_path: public, router_logging: false } | [server](http://docs.grafana.org/installation/configuration/#server) configuration section |
+| `grafana_server` | { protocol: http, enforce_domain: false, socket: "", cert_key: "", cert_file: "", enable_gzip: false, static_root_path: public, router_logging: false } | [server](http://docs.grafana.org/installation/configuration/#server) configuration section |
 | `grafana_security` | { admin_user: admin, admin_password: "" } | [security](http://docs.grafana.org/installation/configuration/#security) configuration section |
 | `grafana_database` | { type: sqlite3 } | [database](http://docs.grafana.org/installation/configuration/#database) configuration section |
-| `grafana_welcome_email_on_sign_up` | False | Send welcome email after signing up |
-| `grafana_users` | { allow_sign_up: False, auto_assign_org_role: Viewer, default_theme: dark } | [users](http://docs.grafana.org/installation/configuration/#users) configuration section |
+| `grafana_welcome_email_on_sign_up` | false | Send welcome email after signing up |
+| `grafana_users` | { allow_sign_up: false, auto_assign_org_role: Viewer, default_theme: dark } | [users](http://docs.grafana.org/installation/configuration/#users) configuration section |
 | `grafana_auth` | {} | [authorization](http://docs.grafana.org/installation/configuration/#auth) configuration section |
 | `grafana_ldap` | {} | [ldap](http://docs.grafana.org/installation/ldap/) configuration section. group_mappings are expanded, see defaults for example |
 | `grafana_session` | {} | [session](http://docs.grafana.org/installation/configuration/#session) management configuration section |
 | `grafana_analytics` | {} | Google [analytics](http://docs.grafana.org/installation/configuration/#analytics) configuration section |
 | `grafana_smtp` | {} | [smtp](http://docs.grafana.org/installation/configuration/#smtp) configuration section |
-| `grafana_alerting` | True | [alerting](http://docs.grafana.org/installation/configuration/#alerting) configuration section |
+| `grafana_alerting` | true | [alerting](http://docs.grafana.org/installation/configuration/#alerting) configuration section |
 | `grafana_metrics` | {} | [metrics](http://docs.grafana.org/installation/configuration/#metrics) configuration section |
 | `grafana_tracing` | {} | [tracing](http://docs.grafana.org/installation/configuration/#tracing) configuration section |
 | `grafana_snapshots` | {} | [snapshots](http://docs.grafana.org/installation/configuration/#snapshots) configuration section |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,17 +73,17 @@ grafana_auth: {}
 #    org_role: Viewer
 #  ldap:
 #    config_file: "/etc/grafana/ldap.toml"
-#    allow_sign_up: False
+#    allow_sign_up: false
 #  basic: true
 
 grafana_ldap: {}
-#  verbose_logging: False
+#  verbose_logging: false
 #  servers:
 #    host: 127.0.0.1
 #    port: 389 # 636 for SSL
-#    use_ssl: False
-#    start_tls: False
-#    ssl_skip_verify: False
+#    use_ssl: false
+#    start_tls: false
+#    ssl_skip_verify: false
 #    root_ca_cert: /path/to/certificate.crt
 #    bind_dn: "cn=admin,dc=grafana,dc=org"
 #    bind_password: grafana

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,45 @@ grafana_auth: {}
 #    allow_sign_up: False
 #  basic: true
 
+grafana_ldap: {}
+#  verbose_logging: False
+#  servers:
+#    host: 127.0.0.1
+#    port: 389 # 636 for SSL
+#    use_ssl: False
+#    start_tls: False
+#    ssl_skip_verify: False
+#    root_ca_cert: /path/to/certificate.crt
+#    bind_dn: "cn=admin,dc=grafana,dc=org"
+#    bind_password: grafana
+#    search_filter: "(cn=%s)" # "(sAMAccountName=%s)" on AD
+#    search_base_dns:
+#      - "dc=grafana,dc=org"
+#    group_search_filter: "(&(objectClass=posixGroup)(memberUid=%s))"
+#    group_search_base_dns:
+#      - "ou=groups,dc=grafana,dc=org"
+#    attributes:
+#      name: givenName
+#      surname: sn
+#      username: sAMAccountName
+#      member_of: memberOf
+#      email: mail
+#  group_mappings:
+#    - name: Main Org.
+#      id: 1
+#      groups:
+#        - group_dn: "cn=admins,ou=groups,dc=grafana,dc=org"
+#          org_role: Admin
+#        - group_dn: "cn=editors,ou=groups,dc=grafana,dc=org"
+#          org_role: Editor
+#        - group_dn: "*"
+#          org_role: Viewer
+#    - name: Alternative Org
+#      id: 2
+#      groups:
+#        - group_dn: "cn=alternative_admins,ou=groups,dc=grafana,dc=org"
+#          org_role: Admin
+
 grafana_session: {}
 #  provider: file
 #  provider_config: "sessions"

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -17,16 +17,16 @@
         org_role: Viewer
       ldap:
         config_file: "/etc/grafana/ldap.toml"
-        allow_sign_up: False
+        allow_sign_up: false
       basic: true
     grafana_ldap:
-      verbose_logging: False
+      verbose_logging: false
       servers:
         host: 127.0.0.1
         port: 389
-        use_ssl: False
-        start_tls: False
-        ssl_skip_verify: False
+        use_ssl: false
+        start_tls: false
+        ssl_skip_verify: false
         root_ca_cert: /path/to/certificate.crt
         bind_dn: "cn=admin,dc=grafana,dc=org"
         bind_password: grafana

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -15,7 +15,48 @@
       anonymous:
         org_name: "Main Organization"
         org_role: Viewer
+      ldap:
+        config_file: "/etc/grafana/ldap.toml"
+        allow_sign_up: False
       basic: true
+    grafana_ldap:
+      verbose_logging: False
+      servers:
+        host: 127.0.0.1
+        port: 389
+        use_ssl: False
+        start_tls: False
+        ssl_skip_verify: False
+        root_ca_cert: /path/to/certificate.crt
+        bind_dn: "cn=admin,dc=grafana,dc=org"
+        bind_password: grafana
+        search_filter: "(cn=%s)"
+        search_base_dns:
+          - "dc=grafana,dc=org"
+        group_search_filter: "(&(objectClass=posixGroup)(memberUid=%s))"
+        group_search_base_dns:
+          - "ou=groups,dc=grafana,dc=org"
+        attributes:
+          name: givenName
+          surname: sn
+          username: sAMAccountName
+          member_of: memberOf
+          email: mail
+      group_mappings:
+        - name: Main Organization
+          id: 1
+          groups:
+            - group_dn: "cn=admins,ou=groups,dc=grafana,dc=org"
+              org_role: Admin
+            - group_dn: "cn=editors,ou=groups,dc=grafana,dc=org"
+              org_role: Editor
+            - group_dn: "*"
+              org_role: Viewer
+        - name: Alternative Org
+          id: 2
+          groups:
+            - group_dn: "cn=alternative_admins,ou=groups,dc=grafana,dc=org"
+              org_role: Admin
     grafana_api_keys:
       - name: "admin"
         role: "Admin"

--- a/molecule/alternative/tests/test_alternative.py
+++ b/molecule/alternative/tests/test_alternative.py
@@ -15,7 +15,8 @@ def test_directories(host):
         "/var/lib/grafana/plugins/raintank-worldping-app"
     ]
     files = [
-        "/etc/grafana/grafana.ini"
+        "/etc/grafana/grafana.ini",
+        "/etc/grafana/ldap.toml"
     ]
     for directory in dirs:
         d = host.file(directory)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,6 +19,19 @@
   no_log: true
   notify: restart grafana
 
+- name: Create grafana LDAP configuration file
+  template:
+    src: ldap.toml.j2
+    dest: "{{ grafana_auth.ldap.config_file | default('/etc/grafana/ldap.toml') }}"
+    owner: root
+    group: grafana
+    mode: 0640
+  when:
+    - "'ldap' in grafana_auth"
+    - "'enabled' not in grafana_auth.ldap or grafana_auth.ldap.enabled"
+  no_log: true
+  notify: restart grafana
+
 - name: Create grafana directories
   file:
     path: "{{ item }}"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -53,3 +53,10 @@
   when:
     - item.role not in ['Viewer', 'Editor', 'Admin']
   with_items: "{{ grafana_api_keys }}"
+
+- name: Fail when grafana_ldap isn't set when grafana_auth.ldap is
+  fail:
+    msg: "You need to configure grafana_ldap.servers and grafana_ldap.group_mappings when grafana_auth.ldap is set"
+  when:
+    - "'ldap' in grafana_auth"
+    - grafana_ldap is not defined or ('servers' not in grafana_ldap or 'group_mappings' not in grafana_ldap)

--- a/templates/ldap.toml.j2
+++ b/templates/ldap.toml.j2
@@ -1,0 +1,33 @@
+# {{ ansible_managed }}
+# Documentation: http://docs.grafana.org/installation/ldap/
+{% if 'verbose_logging' in grafana_ldap %}
+verbose_logging = {{ 'true' if grafana_ldap.verbose_logging else 'false' }}
+{% endif %}
+
+[[servers]]
+{% for k,v in grafana_ldap.servers.items() if k != 'attributes' %}
+{%   if v in [True, False] %}
+{{ k }} = {{ 'true' if v else 'false' }}
+{%   else %}
+{{ k }} = {{ v | to_nice_json }}
+{%   endif %}
+{% endfor %}
+
+[servers.attributes]
+{% for k,v in grafana_ldap.servers.attributes.items() %}
+{{ k }} = {{ v | to_nice_json }}
+{% endfor %}
+
+{% for org in grafana_ldap.group_mappings %}
+{%   if 'name' in org %}
+# {{ org.name }}
+{%   endif %}
+{%   for group in org.groups %}
+[[servers.group_mappings]]
+org_id = {{ org.id }}
+{%     for k,v in group.items() %}
+{{ k }} = "{{ v }}"
+{%     endfor %}
+
+{%   endfor %}
+{% endfor %}


### PR DESCRIPTION
Fixes #11 

This adds a `grafana_ldap` role variable that is used in populating the LDAP configuration file (which can be configured to be something other than the default).

Group mappings are defined on an organization basis rather than a several separate mappings.

There's one shortcoming in this PR - extra organizations aren't created if they're defined. I was thinking I would hit the API to do so, but I'm not sure how I would go about creating organizations with specific IDs correctly (say I defined org 3 before 2 in `group_mappings`, or even skipped `org.id: 2`) when the API (understandably) only lets you create the next available `org_id` with a name.