### PR TITLE
use tox, ansible 2.6, and allow using remote docker host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 *.swp
 *.swo
 *.idea
+.vagrant/
+*.retry
+*.log
+*.swp
+*.swo
+*.idea
 .molecule
 .cache
-*.kate-swp
 __pycache__/
+.pytest_cache
 .tox

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .cache
 *.kate-swp
 __pycache__/
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.3.0,<2.4.0'
-  - ANSIBLE='ansible>=2.4.0,<2.5.0'
-  - ANSIBLE='ansible>=2.5.0,<2.6.0'
+  - ANSIBLE=2.4
+  - ANSIBLE=2.5
+  - ANSIBLE=2.6
 install:
-  - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule>=2.13.0' docker git-semver 'testinfra>=1.7.0'
+  - pip install tox-travis git-semver
 script:
-  - molecule test --all
+  - tox
 deploy:
   provider: script
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 sudo: required
 language: python
 cache: pip
@@ -7,6 +8,8 @@ env:
   - ANSIBLE=2.4
   - ANSIBLE=2.5
   - ANSIBLE=2.6
+matrix:
+  fast_finish: true
 install:
   - pip install tox-travis git-semver
 script:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-kat<p><img src="https://grafana.com/blog/assets/img/blog/timeshift/grafana_release_icon.png" alt="grafana logo" title="grafana" align="right" height="60" /></p>
+<p><img src="https://grafana.com/blog/assets/img/blog/timeshift/grafana_release_icon.png" alt="grafana logo" title="grafana" align="right" height="60" /></p>
 
 # Ansible Role: grafana
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p><img src="https://grafana.com/blog/assets/img/blog/timeshift/grafana_release_icon.png" alt="grafana logo" title="grafana" align="right" height="60" /></p>
+kat<p><img src="https://grafana.com/blog/assets/img/blog/timeshift/grafana_release_icon.png" alt="grafana logo" title="grafana" align="right" height="60" /></p>
 
 # Ansible Role: grafana
 
@@ -12,7 +12,7 @@ Provision and manage [grafana](https://github.com/grafana/grafana) - platform fo
 
 ## Requirements
 
-- Ansible >= 2.3
+- Ansible >= 2.4
 - libselinux-python on deployer host (only when deployer machine has SELinux)
 
 ## Role Variables
@@ -93,17 +93,22 @@ We provide demo site for full monitoring solution based on prometheus and grafan
 
 ## Local Testing
 
-The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/metacloud/molecule) (v2.x). You will have to install Docker on your system. See Get started for a Docker package suitable to for your system.
-All packages you need to can be specified in one line:
+The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/metacloud/molecule) (v2.x). You will have to install Docker on your system. See "Get started" for a Docker package suitable to for your system.
+We are using tox to simplify process of testing on multiple ansible versions. To install tox execute:
 ```sh
-pip install ansible 'ansible-lint>=3.4.15' 'molecule>2.13.0' docker 'testinfra>=1.7.0' jmespath
+pip install tox
 ```
-This should be similar to one listed in `.travis.yml` file in `install` section.
-After installing test suit you can run test by running
+To run tests on all ansible versions (WARNING: this can take some time)
 ```sh
-molecule test --all
+tox
+```
+To run a custom molecule command on custom environment with only default test scenario:
+```sh
+tox -e py27-ansible25 -- molecule test -s default
 ```
 For more information about molecule go to their [docs](http://molecule.readthedocs.io/en/latest/).
+
+If you would like to run tests on remote docker host just specify `DOCKER_HOST` variable before running tox tests.
 
 ## Travis CI
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Pawel Krupa
   description: Grafana - platform for analytics and monitoring
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
   - name: Ubuntu
     versions:

--- a/molecule/alternative/molecule.yml
+++ b/molecule/alternative/molecule.yml
@@ -8,31 +8,37 @@ lint:
 platforms:
   - name: bionic
     image: paulfantom/ubuntu-molecule:18.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: xenial
     image: paulfantom/ubuntu-molecule:16.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: stretch
     image: paulfantom/debian-molecule:9
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: jessie
     image: paulfantom/debian-molecule:8
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: centos7
     image: paulfantom/centos-molecule:7
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: fedora
     image: paulfantom/fedora-molecule:27
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,31 +8,37 @@ lint:
 platforms:
   - name: bionic
     image: paulfantom/ubuntu-molecule:18.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: xenial
     image: paulfantom/ubuntu-molecule:16.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: stretch
     image: paulfantom/debian-molecule:9
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: jessie
     image: paulfantom/debian-molecule:8
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: centos7
     image: paulfantom/centos-molecule:7
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: fedora
     image: paulfantom/fedora-molecule:27
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+molecule>=2.15.0
+docker
+ansible-lint>=3.4.0
+testinfra>=1.7.0
+jmespath

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+minversion = 1.8
+envlist = py{27}-ansible{24,25,26}
+skipsdist = true
+
+[travis:env]
+ANSIBLE=
+  2.4: ansible24
+  2.5: ansible25
+  2.6: ansible26
+
+[testenv]
+passenv = *
+deps =
+    -rtest-requirements.txt
+    ansible24: ansible<2.5
+    ansible25: ansible<2.6
+    ansible26: ansible<2.7
+commands =
+    {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
[minor] - same as in cloudalchemy/ansible-alertmanager#45

- add tox to test suite
- deprecate ansible 2.3 tests
- add ansible 2.6 in test suite
- allow using DOCKER_HOST to run tests on remote docker host