### PR TITLE
Use 'provisioning' capability when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
+| `grafana_use_provisioning` | true | Use Grafana provisioning capalibity when possible (**grafana_version=latest will assume >= 5.0**) |
 | `grafana_system_user` | grafana | Grafana server system user |
 | `grafana_system_group` | grafana | Grafana server system group |
 | `grafana_version` | latest | Grafana package version |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 grafana_version: latest
 
+# Should we use the provisioning capability when possible (provisioning require grafana >= 5.0)
+grafana_use_provisioning: true
+
 grafana_instance: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
 
 grafana_logs_dir: "/var/log/grafana"

--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -1,28 +1,49 @@
 ---
-- name: Check datasources list
-  uri:
-    url: "{{ grafana_url }}/api/datasources"
-    user: "{{ grafana_security.admin_user }}"
-    password: "{{ grafana_security.admin_password }}"
-    force_basic_auth: true
-    return_content: true
-  no_log: true
-  register: datasources
+- block:
+    - name: Check datasources list (api)
+      uri:
+        url: "{{ grafana_url }}/api/datasources"
+        user: "{{ grafana_security.admin_user }}"
+        password: "{{ grafana_security.admin_password }}"
+        force_basic_auth: true
+        return_content: true
+      no_log: true
+      register: datasources
 
-- name: Create grafana datasource
-  uri:
-    url: "{{ grafana_url }}/api/datasources"
-    user: "{{ grafana_security.admin_user }}"
-    password: "{{ grafana_security.admin_password }}"
-    force_basic_auth: true
-    method: POST
-    body_format: json
-    body: "{{ item | to_json }}"
-  with_items: "{{ grafana_datasources }}"
-  no_log: true
-  when: ((datasources['json'] | selectattr("name", "equalto", item['name'])) | list) | length == 0
+    - name: Create grafana datasources (api)
+      uri:
+        url: "{{ grafana_url }}/api/datasources"
+        user: "{{ grafana_security.admin_user }}"
+        password: "{{ grafana_security.admin_password }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: "{{ item | to_json }}"
+      with_items: "{{ grafana_datasources }}"
+      no_log: true
+      when: ((datasources['json'] | selectattr("name", "equalto", item['name'])) | list) | length == 0
 
-- name: Create datasources file
+    - name: Update grafana datasources (api)
+      uri:
+        url: "{{ grafana_url }}/api/datasources/{{ (
+                                                    datasources['json'] |
+                                                    selectattr('name', 'equalto', item['name']) |
+                                                    map(attribute='id') |
+                                                    unique |
+                                                    join()
+                                                   ) }}"
+        user: "{{ grafana_security.admin_user }}"
+        password: "{{ grafana_security.admin_password }}"
+        force_basic_auth: true
+        method: PUT
+        body_format: json
+        body: "{{ item | to_json }}"
+      with_items: "{{ grafana_datasources }}"
+      no_log: true
+      when: ((datasources['json'] | selectattr("name", "equalto", item['name'])) | list) | length != 0
+  when: not grafana_use_provisioning
+
+- name: Create/Update datasources file (provisioning)
   copy:
     dest: "/etc/grafana/provisioning/datasources/ansible.yml"
     content: |
@@ -30,4 +51,6 @@
       datasources:
       {{ grafana_datasources | to_nice_yaml }}
     backup: false
+  become: true
   notify: restart grafana
+  when: grafana_use_provisioning

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -18,10 +18,19 @@
     msg: "You need to specify datasources for dashboards!!!"
   when: grafana_dashboards != [] and grafana_datasources == []
 
+- name: Fail when grafana admin user isn't set
+  fail:
+    msg: "Please specify grafana admin user (grafana_security.admin_user)"
+  when:
+    - grafana_security.admin_user == '' or
+      grafana_security.admin_user is not defined
+
 - name: Fail when grafana admin password isn't set
   fail:
     msg: "Please specify grafana admin password (grafana_security.admin_password)"
-  when: grafana_security.admin_password == ''
+  when:
+    - grafana_security.admin_password == '' or
+      grafana_security.admin_password is not defined
 
 - name: Fail on incorrect variable types in datasource definitions
   fail:
@@ -60,3 +69,10 @@
   when:
     - "'ldap' in grafana_auth"
     - grafana_ldap is not defined or ('servers' not in grafana_ldap or 'group_mappings' not in grafana_ldap)
+
+- name: Force grafana_use_provisioning to false if grafana_version is < 5.0 ( grafana_version is set to '{{ grafana_version }}' )
+  set_fact:
+    grafana_use_provisioning: false
+  when:
+    - grafana_version != 'latest'
+    - grafana_version is version_compare('5.0', '<')


### PR DESCRIPTION
Use 'provisioning' capability when possible
Update datasource via API if already exist
Fix privileges escalation for datasources provisioning
Check that grafana_security.admin_user is set and not empty
Check that grafana_security.admin_password is set

Fix #68 

Provisioning is active by default and is used only for datasources for now
Provisioning is force to be disable if grafana_version < 5.0
Assuming that grafana is >= 5.0 if grafana_version=latest
Let the user the ability to disable provisioning capability if needed

Maybe it will be a good idea to had a new molecule test too to test a previous version who don't provide "provisioning capability ? (like 4.6.0)