### PR TITLE
WIP: Users / Organisations management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swp
 *.swo
 *.idea
+*.pyc
 .molecule
 .cache
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ grafana_organisations:
   - name: "Company C"
 ```
 
+***Since not all fields could be updated (see [Grafana doc](http://docs.grafana.org/http_api/org/#update-organisation)), the use of them will result in trying each time to update the organisation and will break the idempotency of the role***
+
 Accounts example:
+
 ```yaml
 grafana_accounts:
   - name: "UserA"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
 | `grafana_datasources` | [] | List of datasources which should be configured |
+| `grafana_organisations:` | [] | List of organisations which should be configured |
+| `grafana_accounts:` | [] | List of accounts which should be configured |
+| `grafana_accounts_perpage:` | 1000 | How many users which should retrieved by api call |
 
 Datasource example:
 
@@ -69,6 +72,47 @@ grafana_dashboards:
   - dashboard_id: 111
     revision_id: 1
     datasource: prometheus
+```
+
+Organisations example:
+
+```yaml
+grafana_organisations:
+  - name: "Company A"
+  - name: "Company B"
+    address:
+      address1: "company B road"
+      address2:
+      city: "City A"
+      zipCode: "00001"
+      state:
+      country: "Country A"
+  - name: "Company C"
+```
+
+Accounts example:
+```yaml
+grafana_accounts:
+  - name: "UserA"
+     email: "user@companyA.com"
+     login: "user_company_A"
+     password: "userpassword"
+     organisations:
+       - name: "Company A"
+         role: "Admin"
+       - name: "Company B"
+  - name: "UserB"
+     email: "user@companyB.com"
+     login: "user_company_B"
+     password: "userpassword"
+     organisations:
+       - name: "Company B"
+         role: "Admin"
+  - name: "UserC"
+     email: "user@companyC.com"
+     login: "user_company_C"
+     password: "userpassword"
+     organisations: []
 ```
 
 ## Supported CPU Architectures

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,7 +170,38 @@ grafana_image_storage: {}
 # Plugins from https://grafana.com/plugins
 grafana_plugins: []
 #  - raintank-worldping-app
-#
+
+# Organisations to configure
+grafana_organisations: []
+#  - name: "Company A"
+#  - name: "Company B"
+#    address:
+#      address1: "company B road"
+#      address2:
+#      city: "City A"
+#      zipCode: "00001"
+#      state:
+#      country: "Country A"
+#  - name: "Company C"
+
+# Users to configure
+grafana_accounts: []
+#  - name: "User"
+#    email: "user@companyA.com"
+#    login: "user_company_A"
+#    password: "userpassword"
+#    organisations:
+#      - name: "Company A"
+#        role: "Admin"
+#      - name: "Company B"
+#  - name: "User"
+#    email: "user@companyB.com"
+#    login: "user_company_B"
+#    password: "userpassword"
+#    organisations:
+#      - name: "Company B"
+grafana_accounts_perpage: 1000
+
 # Dashboards from https://grafana.com/dashboards
 grafana_dashboards: []
 #  - dashboard_id: '4271'

--- a/filter_plugins/grafana_orgs_filter.py
+++ b/filter_plugins/grafana_orgs_filter.py
@@ -1,6 +1,25 @@
 #!/usr/bin/env python
 from ansible.errors import AnsibleError, AnsibleFilterError
+from collections import OrderedDict
 import json
+
+def grafana_ordered_dict(od, reverse=False, sort_key=None):
+    """Sort nested ordered dict recursively.
+
+    sort_key
+    - sort by dict key case insensitively:
+        sort_key = lambda (k, v): k.lower()
+    """
+    if not isinstance(od, OrderedDict):
+        od = OrderedDict(od)
+
+    res = OrderedDict()
+    for k, v in sorted(od.items(), reverse=reverse, key=sort_key):
+        if isinstance(v, dict):
+            res[k] = grafana_ordered_dict(v)
+        else:
+            res[k] = v
+    return res
 
 def grafana_missing_orgs(actual_orgs, expected_orgs):
     '''
@@ -33,8 +52,40 @@ def grafana_missing_orgs(actual_orgs, expected_orgs):
 
     return missing
 
+def grafana_orgs2update(actual_orgs, expected_orgs):
+    '''
+    1st : fact returned by uri module on grafana api/orgs
+    2nd : a list of organisations dict
+    return: a list of organisations dict who need to be updated
+    '''
+
+    if not actual_orgs['json']:
+        raise AnsibleFilterError('Missing or empty json key into grafana fact')
+
+    if not isinstance(actual_orgs['json'],list):
+        raise AnsibleFilterError('Invalid json key format into grafana fact')
+
+    try:
+        json_data = json.dumps(actual_orgs['json'])
+    except Exception as e:
+        raise AnsibleFilterError("Invalid json string into grafana fact: %s, Error: %s" % (actual_orgs['json'], e))
+
+    if not isinstance(expected_orgs,list):
+        raise AnsibleFilterError('Expected grafana orgs provided is not a list')
+
+    orgs2update = []
+    for dict_expected in expected_orgs:
+        for dict_actual in actual_orgs['json']:
+            if ( 'name', dict_expected['name'] ) in dict_actual.items():
+                dict_expected['id'] = dict_actual['id']
+                if grafana_ordered_dict(dict_expected.items()) != grafana_ordered_dict(dict_actual.items()):
+                    orgs2update.append(dict_expected.copy())
+
+    return orgs2update
+
 class FilterModule(object):
     def filters(self):
         return {
-            'grafana_missing_orgs': grafana_missing_orgs
+            'grafana_missing_orgs': grafana_missing_orgs,
+            'grafana_orgs2update': grafana_orgs2update
         }

--- a/filter_plugins/grafana_orgs_filter.py
+++ b/filter_plugins/grafana_orgs_filter.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+from ansible.errors import AnsibleError, AnsibleFilterError
+import json
+
+def grafana_missing_orgs(actual_orgs, expected_orgs):
+    '''
+    1st : fact returned by uri module on grafana api/orgs
+    2nd : a list of organisations dict
+    return: a list of organisations dict missing in the json
+    '''
+
+    if not actual_orgs['json']:
+        raise AnsibleFilterError('Missing or empty json key into grafana fact')
+
+    if not isinstance(actual_orgs['json'],list):
+        raise AnsibleFilterError('Invalid json key format into grafana fact')
+
+    try:
+        json_data = json.dumps(actual_orgs['json'])
+    except Exception as e:
+        raise AnsibleFilterError("Invalid json string into grafana fact: %s, Error: %s" % (actual_orgs['json'], e))
+
+    if not isinstance(expected_orgs,list):
+        raise AnsibleFilterError('Expected grafana orgs provided is not a list')
+
+    missing = []
+    for dict_expected in expected_orgs:
+        for dict_actual in actual_orgs['json']:
+            if ( 'name', dict_expected['name'] ) in dict_actual.items():
+                break
+        else:
+           missing.append(dict_expected.copy()) 
+
+    return missing
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'grafana_missing_orgs': grafana_missing_orgs
+        }

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -90,3 +90,30 @@
         basicAuthPassword: "password"
         isDefault: true
         jsonData: '{"tlsAuth":false,"tlsAuthWithCACert":false,"tlsSkipVerify":true}'
+    grafana_organisations:
+      - name: "Company A"
+      - name: "Company B"
+        address:
+          address1: "company B road"
+          address2:
+          city: "City B"
+          zipCode: "0000"
+          state:
+          country: "Country B"
+      - name: "Company C"
+    grafana_accounts:
+      - name: "UserA"
+        email: "user@companyA.com"
+        login: "user_company_A"
+        password: "userpassword"
+        organisations:
+          - name: "Company A"
+            role: "Admin"
+          - name: "Company B"
+      - name: "UserB"
+        email: "user@companyB.com"
+        login: "user_company_B"
+        password: "userpassword"
+        organisations:
+          - name: "Company B"
+    grafana_accounts_perpage: 1

--- a/tasks/accounts.yml
+++ b/tasks/accounts.yml
@@ -1,0 +1,165 @@
+---
+- name: Fetch the number of page of users to parse (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/users/search?perpage=1&page=1"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    body_format: json
+  no_log: true
+  register: _grafana_accounts_first_page
+
+- name: Debug _grafana_accounts_first_page
+  debug:
+    var: _grafana_accounts_first_page
+  when:
+    - _grafana_accounts_first_page is defined
+  tags:
+    - never
+    - debug
+
+- name: Fetch all users (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/users/search?perpage={{ grafana_accounts_perpage }}&page={{ item }}"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    body_format: json
+  no_log: true
+  register: _grafana_accounts
+  with_items: "{{range(
+                        1,
+                        (
+                          (_grafana_accounts_first_page.json.totalCount / grafana_accounts_perpage )
+                          | round(0,'ceil')
+                          | int
+                        ) + 1
+                      )
+                      | list
+              }}"
+
+- name: Debug _grafana_accounts
+  debug:
+    var: _grafana_accounts
+  when:
+    - _grafana_accounts is defined
+  tags:
+    - never
+    - debug
+
+- name: Create users not already present (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/admin/users"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: POST
+    body_format: json
+    body: "{{ item | to_json }}"
+  no_log: true
+  register: _grafana_accounts_created
+  changed_when: true
+  with_items:
+    # If the email or the login are not already present
+    - "{{
+          grafana_accounts
+          | rejectattr('login','match', (
+                                          _grafana_accounts.results
+                                          | sum(attribute='json.users',start=[])
+                                          | map(attribute='login')
+                                          | join('|')
+                                        )
+                      )
+          | rejectattr('email','match', (
+                                          _grafana_accounts.results
+                                          | sum(attribute='json.users',start=[])
+                                          | map(attribute='email')
+                                          | map('regex_escape')
+                                          | join('|')
+                                        )
+                      )
+          | list
+      }}"
+
+- name: Debug _grafana_accounts_created
+  debug:
+    var: _grafana_accounts_created
+  when:
+    - _grafana_accounts_created is defined
+    - _grafana_accounts_created.results != []
+  tags:
+    - never
+    - debug
+
+- name: Update users if needed
+  uri:
+    url: "{{ grafana_api_url }}/api/users/{{
+                                      (
+                                      _grafana_accounts.results
+                                      | sum(attribute='json.users',start=[])
+                                      | selectattr('login','equalto', item.login)
+                                      | map(attribute='id') | list
+                                      +
+                                      _grafana_accounts.results
+                                      | sum(attribute='json.users',start=[])
+                                      | selectattr('email','equalto', item.email)
+                                      | map(attribute='id') | list
+                                      ) | first
+                                      }}"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: PUT
+    body_format: json
+    body: "{{ item | to_json }}"
+  no_log: true
+  register: _grafana_accounts_updated
+  changed_when: true
+  with_items:
+    # If the user already exist
+    - "{{
+    (
+    grafana_accounts
+    | selectattr('login','match', (
+                                    _grafana_accounts.results
+                                    | sum(attribute='json.users',start=[])
+                                    | map(attribute='login')
+                                    | map('regex_escape')
+                                    | join('|')
+                                  )
+    ) | list
+    +
+    grafana_accounts
+    | selectattr('email','match', (
+                                    _grafana_accounts.results
+                                    | sum(attribute='json.users',start=[])
+                                    | map(attribute='email')
+                                    | map('regex_escape')
+                                    | join('|')
+                                  )
+    ) | list
+    ) | unique | list
+    }}"
+  when:
+    # Only if name / login / email changed
+    - _grafana_accounts.results
+        | sum(attribute='json.users',start=[])
+        | selectattr('name','equalto',item.name)
+        | list | length == 0
+      or _grafana_accounts.results
+        | sum(attribute='json.users',start=[])
+        | selectattr('login','equalto',item.login)
+        | list | length == 0
+      or _grafana_accounts.results
+        | sum(attribute='json.users',start=[])
+        | selectattr('email','equalto',item.email)
+        | list | length == 0
+
+- name: Debug _grafana_accounts_updated
+  debug:
+    var: _grafana_accounts_updated
+  when:
+    - _grafana_accounts_updated is defined
+  tags:
+    - never
+    - debug

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,7 @@
     - "/etc/grafana/datasources"
     - "/etc/grafana/provisioning"
     - "/etc/grafana/provisioning/datasources"
+  become: true
 
 - name: Create grafana main configuration file
   template:
@@ -18,6 +19,7 @@
     mode: 0640
   no_log: true
   notify: restart grafana
+  become: true
 
 - name: Create grafana LDAP configuration file
   template:
@@ -31,6 +33,7 @@
     - "'enabled' not in grafana_auth.ldap or grafana_auth.ldap.enabled"
   no_log: true
   notify: restart grafana
+  become: true
 
 - name: Create grafana directories
   file:
@@ -44,6 +47,7 @@
     - "{{ grafana_data_dir }}"
     - "{{ grafana_data_dir }}/dashboards"
     - "{{ grafana_data_dir }}/plugins"
+  become: true
 
 - name: Enable and start Grafana systemd unit
   systemd:
@@ -51,3 +55,4 @@
     enabled: true
     state: started
     daemon_reload: true
+  become: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,7 @@
   until: _install_dep_packages is succeeded
   retries: 5
   delay: 2
+  become: true
 
 - name: Remove conflicting grafana packages
   package:
@@ -21,6 +22,7 @@
   when:
     - old_grafana_pkgs is changed
     - ansible_pkg_mgr == "apt"
+  become: true
 
 - name: Add Grafana repository file [RHEL/CentOS]
   template:
@@ -29,6 +31,7 @@
     force: true
     backup: true
   when: ansible_pkg_mgr in ['yum', 'dnf']
+  become: true
 
 - block:
     - name: Import Grafana GPG signing key [Debian/Ubuntu]
@@ -86,6 +89,7 @@
       delay: 2
   when:
     - ansible_pkg_mgr == "apt"
+  become: true
 
 - name: Install Grafana
   package:
@@ -96,3 +100,4 @@
   retries: 5
   delay: 2
   notify: restart grafana
+  become: true

--- a/tasks/links_accounts_organisations.yml
+++ b/tasks/links_accounts_organisations.yml
@@ -1,0 +1,152 @@
+---
+- include_tasks: organisations.yml
+  when:
+    - _grafana_organisations_created.results  | length > 0
+
+- include_tasks: accounts.yml
+  when:
+    - _grafana_accounts_created.results | length > 0
+    - _grafana_accounts_updated.results | length > 0
+
+- name: Fetch all users <-> organisations links (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/org/users"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    body_format: json
+    headers:
+      X-Grafana-Org-Id: "{{ item }}"
+  no_log: true
+  register: _grafana_accounts_organisations_links
+  with_items: "{{ _grafana_organisations.json | map(attribute='id') | list }}"
+
+- name: Debug _grafana_accounts_organisations_links
+  debug:
+    var: _grafana_accounts_organisations_links
+  when:
+    - _grafana_accounts_organisations_links is defined
+  tags:
+    - never
+    - debug
+
+- name: Add users to the needed organisations (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/orgs/{{
+                                      _grafana_organisations.json
+                                      | selectattr('name','equalto', item.1.name)
+                                      | map(attribute='id')
+                                      | unique
+                                      | join()
+                                      | int
+                                    }}/users"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: POST
+    body_format: json
+    body: |
+      {
+        "loginOrEmail": "{{ item.0.login }}",
+        "role": "{{
+                    item.1.role
+                    | default(grafana_users.auto_assign_org_role)
+                 }}"
+      }
+  no_log: true
+  register: _grafana_accounts_organisations_links_created
+  changed_when: true
+  with_subelements:
+    - "{{ grafana_accounts }}"
+    - organisations
+  when:
+    # If the user is not already present in the organisation
+    - _grafana_accounts_organisations_links.results | sum(attribute='json', start=[])
+      | selectattr('email', 'equalto', item.0.email)
+      | selectattr('orgId', 'equalto',
+          (
+            _grafana_organisations.json
+            | selectattr('name', 'equalto', item.1.name)
+            | map(attribute='id')
+            | unique
+            | join()
+            | int
+          )
+        )
+      | list
+      | length == 0
+
+- name: Debug _grafana_accounts_organisations_links_created
+  debug:
+    var: _grafana_accounts_organisations_links_created
+  when:
+    - _grafana_accounts_organisations_links_created is defined
+  tags:
+    - never
+    - debug
+
+- name: Update users role if needed (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/orgs/{{
+                                      _grafana_organisations.json
+                                      | selectattr('name','equalto', item.1.name)
+                                      | map(attribute='id')
+                                      | unique
+                                      | join()
+                                      | int
+                                    }}/users/{{
+                                      _grafana_accounts.results
+                                      | sum(attribute='json.users', start=[])
+                                      | selectattr('login', 'equalto', item.0.login)
+                                      | map(attribute='id')
+                                      | unique
+                                      | join()
+                                      | int
+                                    }}"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: PATCH
+    body_format: json
+    body: |
+      {
+        "role": "{{
+                    item.1.role
+                    | default(grafana_users.auto_assign_org_role)
+                }}"
+      }
+  no_log: true
+  register: _grafana_accounts_organisations_links_updated
+  changed_when: true
+  with_subelements:
+    - "{{ grafana_accounts }}"
+    - organisations
+  when:
+    # If user exist in this organisation and the role is not the same
+    - _grafana_accounts_organisations_links.results
+      | sum(attribute='json', start=[])
+      | selectattr('email', 'equalto', item.0.email)
+      | selectattr('orgId', 'equalto', (
+                                        _grafana_organisations.json
+                                        | selectattr('name', 'equalto', item.1.name)
+                                        | map(attribute='id')
+                                        | unique
+                                        | join()
+                                        | int
+                                      )
+        )
+      | rejectattr('role', 'equalto', (
+                                        item.1.role
+                                        | default(grafana_users.auto_assign_org_role, True)
+                                      )
+        )
+      | list | length > 0
+
+- name: Debug _grafana_accounts_organisations_links_updated
+  debug:
+    var: _grafana_accounts_organisations_links_updated
+  when:
+    - _grafana_accounts_organisations_links_updated is defined
+  tags:
+    - never
+    - debug

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,26 @@
   tags:
     - always
 
+- include: organisations.yml
+  when: grafana_organisations | length > 0
+  tags:
+    - configure
+    - organisations
+    - links
+
+- include: accounts.yml
+  when: grafana_accounts | length > 0
+  tags:
+    - configure
+    - accounts
+    - links
+
+- include: links_accounts_organisations.yml
+  when: grafana_accounts | map(attribute='organisations') | list | length > 0
+  tags:
+    - configure
+    - links
+
 - include: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:

--- a/tasks/organisations.yml
+++ b/tasks/organisations.yml
@@ -9,6 +9,9 @@
   no_log: true
   register: _grafana_organisations
 
+- debug:
+    msg: "{{ _grafana_organisations }}"
+
 - name: Create orgs not already present (api)
   uri:
     url: "{{ grafana_api_url }}/api/orgs"
@@ -22,3 +25,17 @@
   register: _grafana_organisations_created
   changed_when: true
   with_items: "{{ _grafana_organisations | grafana_missing_orgs(grafana_organisations) }}"
+
+- name: Update orgs who need to be updated (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/orgs/{{ item.id }}"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: PUT
+    body_format: json
+    body: "{{ item | to_json }}"
+  no_log: true
+  register: _grafana_organisations_updated
+  changed_when: true
+  with_items: "{{ _grafana_organisations | grafana_orgs2update(grafana_organisations) }}"

--- a/tasks/organisations.yml
+++ b/tasks/organisations.yml
@@ -9,15 +9,6 @@
   no_log: true
   register: _grafana_organisations
 
-- name: Debug _grafana_organisations
-  debug:
-    var: _grafana_organisations
-  when:
-    - _grafana_organisations is defined
-  tags:
-    - never
-    - debug
-
 - name: Create orgs not already present (api)
   uri:
     url: "{{ grafana_api_url }}/api/orgs"
@@ -26,32 +17,8 @@
     force_basic_auth: true
     method: POST
     body_format: json
-    body: "{{
-              grafana_organisations
-              | selectattr('name', 'equalto', item) | first | to_json
-          }}"
+    body: "{{ item | to_json }}"
   no_log: true
   register: _grafana_organisations_created
   changed_when: true
-  with_items:
-    - "{{
-          (
-            grafana_organisations
-            | map(attribute='name')
-            | list
-          )
-          | difference(
-                _grafana_organisations['json']
-                | map(attribute='name')
-                | list
-            )
-      }}"
-
-- name: Debug _grafana_organisations_created
-  debug:
-    var: _grafana_organisations_created
-  when:
-    - _grafana_organisations_created is defined
-  tags:
-    - never
-    - debug
+  with_items: "{{ _grafana_organisations | grafana_missing_orgs(grafana_organisations) }}"

--- a/tasks/organisations.yml
+++ b/tasks/organisations.yml
@@ -1,0 +1,57 @@
+---
+- name: Fetch all existing orgs (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/orgs"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    body_format: json
+  no_log: true
+  register: _grafana_organisations
+
+- name: Debug _grafana_organisations
+  debug:
+    var: _grafana_organisations
+  when:
+    - _grafana_organisations is defined
+  tags:
+    - never
+    - debug
+
+- name: Create orgs not already present (api)
+  uri:
+    url: "{{ grafana_api_url }}/api/orgs"
+    user: "{{ grafana_security.admin_user }}"
+    password: "{{ grafana_security.admin_password }}"
+    force_basic_auth: true
+    method: POST
+    body_format: json
+    body: "{{
+              grafana_organisations
+              | selectattr('name', 'equalto', item) | first | to_json
+          }}"
+  no_log: true
+  register: _grafana_organisations_created
+  changed_when: true
+  with_items:
+    - "{{
+          (
+            grafana_organisations
+            | map(attribute='name')
+            | list
+          )
+          | difference(
+                _grafana_organisations['json']
+                | map(attribute='name')
+                | list
+            )
+      }}"
+
+- name: Debug _grafana_organisations_created
+  debug:
+    var: _grafana_organisations_created
+  when:
+    - _grafana_organisations_created is defined
+  tags:
+    - never
+    - debug

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -76,3 +76,104 @@
   when:
     - grafana_version != 'latest'
     - grafana_version is version_compare('5.0', '<')
+
+- name: Fail if an organisation is present twice into the organisations definition
+  fail:
+    msg: "An organisation is present twice into grafana_organisations"
+  when:
+    (
+      grafana_organisations
+      | map(attribute='name') | list
+      | length
+    )
+    !=
+    (
+      grafana_organisations
+      | map(attribute='name')
+      | unique | list
+      | length
+    )
+
+- name: Fail if a user doesn't have an email set
+  fail:
+    msg: "A user doesn't have an email set"
+  when:
+    (
+      grafana_accounts
+      | length
+    )
+    !=
+    (
+      grafana_accounts
+      | selectattr('email','defined')
+      | list
+      | length
+    )
+
+- name: Fail if a user doesn't have a login set
+  fail:
+    msg: "A user doesn't have a login set"
+  when:
+    (
+      grafana_accounts
+      | length
+    )
+    !=
+    (
+      grafana_accounts
+      | selectattr('login','defined')
+      | list
+      | length
+    )
+
+- name: Fail if a login is present twice into the users definition
+  fail:
+    msg: "A login is present twice into grafana_accounts"
+  when:
+    (
+      grafana_accounts
+      | map(attribute='login')
+      | list
+      | length
+    )
+    !=
+    (
+      grafana_accounts
+      | map(attribute='login')
+      | unique | list
+      | length
+    )
+
+- name: Fail if an email is present twice into the users definition
+  fail:
+    msg: "An email is present twice into grafana_accounts"
+  when:
+    (
+      grafana_accounts
+      | map(attribute='email') | list
+      | length
+    )
+    !=
+    (
+      grafana_accounts
+      | map(attribute='email')
+      | unique | list
+      | length
+    )
+
+- name: Fail if an organisation exist in accounts definition but not in organisations definition
+  fail:
+    msg: "An organisation describe into grafana_accounts doesn't exist into grafana_organisations"
+  when:
+    (
+      grafana_accounts
+      | sum(attribute='organisations',start=[]) | list
+      | map(attribute='name') | list
+      | unique | list
+    )
+    | difference(
+        grafana_organisations
+        | map(attribute='name') | list
+        | unique | list
+      )
+    | length != 0


### PR DESCRIPTION
First try to solve #12 
Fix some permissions escalation
Add an alternative molecule test with 4.6.3 version to validate that is functional with 4.6.3 and >5.0 

Comments welcome
Feel free to ask if something is not clear

Too many jinja filter tricks FMPOV but tried to write it to be readable and understandable.

Organisations informations can't be updated right now.

Users can be updated ( email and login need to be updated separately in 2 run, if not, it will result in a new user )
Users can be linked to multiple organisations with different role
Users are linked to organisation 1 by default even if some organisations are specified ( need to update this to unlink them of organisation 1 if there are some organisations specified inside the accounts to only let the specified ones)

What i want / is needed to add:

- async where it is possible
- clean users / organisations not managed by ansible ( but users who have update both login/email by the UI will be deleted and recreated with the original informations. Seems it is not possible to denied the user to update his login itself through the UI.... )
- link dashboard to specified organisations
- link datasource to specified organisations

Even if i tried it a few times, some unknown bugs surely exist ^^

Regards,