### PR TITLE
datasource format fix

### DIFF
--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -47,7 +47,8 @@
   copy:
     dest: "/etc/grafana/provisioning/datasources/ansible.yml"
     content: |
-      delete_datasources: []
+      apiVersion: 1
+      deleteDatasources: []
       datasources:
       {{ grafana_datasources | to_nice_yaml }}
     backup: false


### PR DESCRIPTION
This is format which is used in newer version of Grafana.
We should have `apiVersion` if it's not there I had problems with `jsonData` not being read by Grafana.
Also `delete_datasources` should be `deleteDatasources`.