### PR TITLE
Specify apiVersion in datasources provisioning file

### DIFF
--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -47,7 +47,8 @@
   copy:
     dest: "/etc/grafana/provisioning/datasources/ansible.yml"
     content: |
-      delete_datasources: []
+      apiVersion: 1
+      deleteDatasources: []
       datasources:
       {{ grafana_datasources | to_nice_yaml }}
     backup: false


### PR DESCRIPTION
The datasource provisioning isn’t working properly for me with Grafana 5.2.x. It won’t import the following fields:

* basicAuth
* basicAuthUser
* basicAuthPassword:
* isDefault

Also, I saw the following log message in the Grafana log during restart:

```
t=2018-08-05T21:14:08+0200 lvl=warn msg="[Deprecated] the datasource provisioning config is outdated. please upgrade" logger=provisioning.datasources filename=/etc/grafana/provisioning/datasources/ansible.yml
```

By reading https://github.com/grafana/grafana/blob/6f1b125c489a3ed9282ec004cb56ba35d892356d/pkg/services/provisioning/datasources/config_reader.go#L80, I found out that the lack of the `apiVersion` field in the provisioning file caused the config parser to treat it as an old config file, presumably with fewer support fields.

I fixed it by adjusting the task to write a provisioning file according to http://docs.grafana.org/administration/provisioning/#example-datasource-config-file.