### PR TITLE
repeat plugin installation on network failure

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -11,5 +11,9 @@
   args:
     creates: "{{ grafana_data_dir }}/plugins/{{ item }}"
   with_items: "{{ grafana_plugins | difference(installed_plugins.files) }}"
+  register: _plugin_install
+  until: _plugin_install is succeeded
+  retries: 5
+  delay: 2
   notify:
     - restart grafana


### PR DESCRIPTION
Plugin installation is dependant on network so role should be able to repeat installation on network failures.