### PR TITLE
Fixed syntax in default/main.yml to avoid unmarshal errors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -203,7 +203,10 @@ grafana_datasources: []
 #    basicAuthUser: "admin"
 #    basicAuthPassword: "password"
 #    isDefault: true
-#    jsonData: '{"tlsAuth":false,"tlsAuthWithCACert":false,"tlsSkipVerify":true}'
+#    jsonData:
+#      tlsAuth: false
+#      tlsAuthWithCACert: false
+#      tlsSkipVerify: true
 
 # API keys to configure
 grafana_api_keys: []


### PR DESCRIPTION
Fixed the syntax in the sample comment for the Datasource in default / main.yml to avoid the error:
`lvl=eror msg="Server shutdown" logger=server reason="Service init failed: Datasource provisioning error: yaml: unmarshal errors:\n  line 7: cannot unmarshal !!str `{\"tlsAu...` into map[string]interface {}`