### PR TITLE
fixes for handling LDAP template booleans in grafana groups section (issue #103)

### DIFF
--- a/templates/ldap.toml.j2
+++ b/templates/ldap.toml.j2
@@ -26,7 +26,11 @@ verbose_logging = {{ 'true' if grafana_ldap.verbose_logging else 'false' }}
 [[servers.group_mappings]]
 org_id = {{ org.id }}
 {%     for k,v in group.items() %}
+{%   if v in [True, False] %}
+{{ k }} = {{ 'true' if v else 'false' }}
+{%   else %}
 {{ k }} = "{{ v }}"
+{%   endif %}
 {%     endfor %}
 
 {%   endfor %}


### PR DESCRIPTION
Corrected handling of boolean values in ldap.toml generation template in grafana groups section 

closes #103 