### PR TITLE
(postgresql) remote db & user creation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,13 +42,21 @@ grafana_security:
 #  data_source_proxy_whitelist:
 
 # Database setup
+
+# Automatically create grafana DB & db user, only for Postgresql 
+# grafana_db_creation:
+#  enabled: True
+#  master_user: 
+#  master_password: 
+#  host: 
+#  port: 5432
 grafana_database:
   type: sqlite3
-#  host: 127.0.0.1:3306
-#  name: grafana
-#  user: root
-#  password: ""
-#  url: ""
+#  type: postgres
+#  host: "{{ grafana_db_creation['host'] }}:{{ grafana_db_creation['port'] }}"
+#  user: 
+#  name: 
+#  password: 
 #  ssl_mode: disable
 #  path: grafana.db
 #  max_idle_conn: 2

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -60,3 +60,9 @@
   retries: 5
   delay: 2
   notify: restart grafana
+
+- name: "Installing the postgresql database"
+  include: "postgresql.yml"
+  when:
+    - grafana_database['type'] == "postgres"
+    - grafana_db_creation['enabled']

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,0 +1,40 @@
+- name: "Debian | Install PostgreSQL Client package"
+  apt:
+    name: postgresql-client
+    state: present
+  when:
+    - grafana_database['type'] == "postgres"
+    - grafana_db_creation['enabled']
+  tags:
+    - grafana
+    - database
+
+- name: "PostgreSQL | Remote"
+  block:
+    - name: "PostgreSQL | Remote | Create database"
+      postgresql_db:
+        login_host: "{{ grafana_db_creation['host'] | default(omit)}}"
+        login_user: "{{ grafana_db_creation['master_user'] | default(omit) }}"
+        login_password: "{{ grafana_db_creation['master_password'] | default(omit) }}"
+        login_unix_socket: "{{ grafana_db_creation['unix_socket'] | default(omit) }}"
+        name: "{{ grafana_database['name'] }}"
+        port: "{{ grafana_db_creation['port'] }}"
+        state: present
+    - name: "PostgreSQL | Remote | Create database user"
+      postgresql_user:
+        login_host: "{{ grafana_db_creation['host'] | default(omit)}}"
+        login_user: "{{ grafana_db_creation['master_user']| default(omit) }}"
+        login_password: "{{ grafana_db_creation['master_password'] | default(omit) }}"
+        db: "{{ grafana_database['name'] }}"
+        name: "{{ grafana_database['user'] }}"
+        password: "md5{{ (grafana_database['password'] + grafana_database['user'])|hash('md5') }}"
+        port: "{{ grafana_db_creation['port'] }}"
+        priv: ALL
+        state: present
+        encrypted: yes
+  when:
+    - grafana_database['type'] == "postgres"
+    - grafana_db_creation['enabled']
+  tags:
+    - grafana
+    - database


### PR DESCRIPTION
Adding the option to create DB & DB user in a remote postgresql DB (tested with RDS)
only active when grafana_database['type'] == postgresql && grafana_db_creation['enabled'] == true
In order to create the new database you will need to change the next vars:

grafana_db_creation:
  enabled: True # Create DB & User
  master_user: # DB User with permissions to create new database & user
  master_password: # Password
  host: # Remote DB host
  port: 5432 # Remote DB port

I changed the default grafana_database['host'] to use the above host & port to prevent duplications.
host: "{{ grafana_db_creation['host'] }}:{{ grafana_db_creation['port'] }}"
