### PR TITLE
Fix: make curl fail when we encounter a 404

### DIFF
--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -26,7 +26,7 @@
 # Use curl to solve issue #77
 - name: download grafana dashboard from grafana.net to local directory
   become: false
-  command: "curl --compressed https://grafana.com/api/dashboards/{{ item.dashboard_id }}/revisions/{{ item.revision_id }}/download -o /tmp/dashboards/{{ item.dashboard_id }}.json"
+  command: "curl --fail --compressed https://grafana.com/api/dashboards/{{ item.dashboard_id }}/revisions/{{ item.revision_id }}/download -o /tmp/dashboards/{{ item.dashboard_id }}.json"
   args:
     creates: "/tmp/dashboards/{{ item.dashboard_id }}.json"
     warn: false


### PR DESCRIPTION
 - this happens when you supply a dashboard ID (or revision) which does not exist
 - currently, the error (json) is downloaded and then uploaded to grafana (which fails)
 - this patch/fix should uncover that problem more easily