### PR TITLE
Replaced tag always, which colidate when including role. 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,57 +8,73 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - include: preflight.yml
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - include: install.yml
   become: true
   tags:
-    - install
+    - grafana_install
 
 - include: configure.yml
   become: true
   tags:
-    - configure
+    - grafana_configure
 
 - include: plugins.yml
   when: grafana_plugins != []
   tags:
-    - configure
+    - grafana_configure
 
 - name: Restart grafana before configuring datasources and dashboards
   meta: flush_handlers
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - name: Wait for grafana to start
   wait_for:
     host: "{{ grafana_address }}"
     port: "{{ grafana_port }}"
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - include: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:
-    - configure
+    - grafana_configure
 
 - include: datasources.yml
   when: grafana_datasources != []
   tags:
-    - configure
-    - datasources
+    - grafana_configure
+    - grafana_datasources
 
 - include: notifications.yml
   when: grafana_alert_notifications | length > 0
   tags:
-    - configure
-    - notifications
+    - grafana_configure
+    - grafana_notifications
 
 - include: dashboards.yml
   tags:
-    - configure
-    - dashboards
+    - grafana_configure
+    - grafana_dashboards

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0
 jmespath
-pytests==3.9.3
+pytest==3.9.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0
 jmespath
+pytests==3.9.3

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,4 @@ deps =
     ansible26: ansible<2.7
     ansible27: ansible<2.8
 commands =
-    {posargs:molecule test --all --destroy always}
+    {posargs:molecule test --all --destroy=always}


### PR DESCRIPTION
Renamed tags to include service name, for better handling with other roles.

This solves #101 by which I was affected as well. 
Additionally tag naming will help, to ie. configure only grafana, not also prometheus, if both roles are included in your task.