### PR TITLE
Few smaller improvements, backward compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_tracing` | {} | [tracing](http://docs.grafana.org/installation/configuration/#tracing) configuration section |
 | `grafana_snapshots` | {} | [snapshots](http://docs.grafana.org/installation/configuration/#snapshots) configuration section |
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
+| `grafana_manage_dashboards` | true | Defines if dashboards should be managed by Ansible (will overwrite exisiting) |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
 | `grafana_datasources` | [] | List of datasources which should be configured |
+| `grafana_environment` | {} | Optional Environment param for Grafana installation, usefull ie for setting http_proxy |
 
 Datasource example:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,7 +170,10 @@ grafana_image_storage: {}
 # Plugins from https://grafana.com/plugins
 grafana_plugins: []
 #  - raintank-worldping-app
-#
+
+# Should grafana dashboards be managed by Ansible
+grafana_manage_dashboards: true
+
 # Dashboards from https://grafana.com/dashboards
 grafana_dashboards: []
 #  - dashboard_id: '4271'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -222,3 +222,5 @@ grafana_api_keys: []
 
 # The location where the keys should be stored.
 grafana_api_keys_dir: "{{ lookup('env', 'HOME') }}/grafana/keys"
+
+grafana_environment: {}

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -7,6 +7,7 @@
     mode: 0755
   delegate_to: localhost
   run_once: true
+  check_mode: false
 
 # - name: download grafana dashboard from grafana.net to local folder
 #   become: false
@@ -40,6 +41,7 @@
   when: grafana_dashboards | length > 0
   tags:
     - skip_ansible_lint
+  check_mode: false
 
 # As noted in [1] an exported dashboard replaces the exporter's datasource
 # name with a representative name, something like 'DS_GRAPHITE'. The name

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,6 +50,7 @@
       delay: 2
   when:
     - ansible_pkg_mgr == "apt"
+  environment: "{{ grafana_environment | default(omit) }}"
 
 - name: Install Grafana
   package:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,7 +50,7 @@
       delay: 2
   when:
     - ansible_pkg_mgr == "apt"
-  environment: "{{ grafana_environment | default(omit) }}"
+  environment: "{{ grafana_environment }}"
 
 - name: Install Grafana
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,57 +8,73 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - include: preflight.yml
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - include: install.yml
   become: true
   tags:
-    - install
+    - grafana_install
 
 - include: configure.yml
   become: true
   tags:
-    - configure
+    - grafana_configure
 
 - include: plugins.yml
   when: grafana_plugins != []
   tags:
-    - configure
+    - grafana_configure
 
 - name: Restart grafana before configuring datasources and dashboards
   meta: flush_handlers
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - name: Wait for grafana to start
   wait_for:
     host: "{{ grafana_address }}"
     port: "{{ grafana_port }}"
   tags:
-    - always
+    - grafana_install
+    - grafana_configure
+    - grafana_datasources
+    - grafana_notifications
+    - grafana_dashboards
 
 - include: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:
-    - configure
+    - grafana_configure
 
 - include: datasources.yml
   when: grafana_datasources != []
   tags:
-    - configure
-    - datasources
+    - grafana_configure
+    - grafana_datasources
 
 - include: notifications.yml
   when: grafana_alert_notifications | length > 0
   tags:
-    - configure
-    - notifications
+    - grafana_configure
+    - grafana_notifications
 
 - include: dashboards.yml
   tags:
-    - configure
-    - dashboards
+    - grafana_configure
+    - grafana_dashboards

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,6 +75,7 @@
     - grafana_notifications
 
 - include: dashboards.yml
+  when: grafana_manage_dashboards
   tags:
     - grafana_configure
     - grafana_dashboards

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0
 jmespath
-pytests==3.9.3
+pytest==3.9.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0
 jmespath
+pytests==3.9.3

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,4 @@ deps =
     ansible26: ansible<2.7
     ansible27: ansible<2.8
 commands =
-    {posargs:molecule test --all --destroy always}
+    {posargs:molecule test --all --destroy=always}


### PR DESCRIPTION
- Fixed running role in check_mode, so it's not failing anymore
- Added environment param for getting GPG key and installing Grafana - usefull, when you have to use PROXY
- Added option to disable managing dashboards. Useful when you modify them manually via web interface. 