### PR TITLE
Only set alerting if variable is false

### DIFF
--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -96,9 +96,9 @@ enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
 # Alerting
-{% if grafana_alerting %}
+{% if grafana_alerting == false %}
 [alerting]
-enabled = True
+enabled = False
 ;execute_alerts = true
 {% endif %}
 

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -96,9 +96,9 @@ enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
 # Alerting
-{% if grafana_alerting == false %}
+{% if not grafana_alerting %}
 [alerting]
-enabled = False
+enabled = false
 ;execute_alerts = true
 {% endif %}
 


### PR DESCRIPTION
The current configuration template doesn't allow for disabling the alerting. It is enabled by default. This small patch makes sure we can disable the alerting.