### PR TITLE
Allow disabling of Grafana alerts

### DIFF
--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -96,11 +96,13 @@ enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
 # Alerting
-{% if not grafana_alerting %}
 [alerting]
+{% if grafana_alerting %}
+enabled = true
+{% else %}
 enabled = false
-;execute_alerts = true
 {% endif %}
+;execute_alerts = true
 
 # SMTP and email config
 {% if grafana_smtp != {} %}


### PR DESCRIPTION
The default of this setting is `true` now (opposed to what the Grafana docs say):

https://github.com/grafana/grafana/blob/master/conf/defaults.ini#L468

I. e. with the current usage of the `grafana_alerting` variable it's not possible to disable the Grafana alerting UI.