### PR TITLE
Add support for multi-line ansible_managed strings

### DIFF
--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 # More informations:
 # http://docs.grafana.org/installation/configuration
 # https://github.com/grafana/grafana/blob/master/conf/sample.ini

--- a/templates/grafana.yum.repo.j2
+++ b/templates/grafana.yum.repo.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 [grafana]
 name=grafana
 baseurl=https://packagecloud.io/grafana/stable/el/7/$basearch

--- a/templates/ldap.toml.j2
+++ b/templates/ldap.toml.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 # Documentation: http://docs.grafana.org/installation/ldap/
 {% if 'verbose_logging' in grafana_ldap %}
 verbose_logging = {{ 'true' if grafana_ldap.verbose_logging else 'false' }}


### PR DESCRIPTION
This'll support multi-line ansible_managed strings but will not work on ansible 1.x.