### PR TITLE
Enable the use of ports below 1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_data_dir` | /var/lib/grafana | Path to database directory |
 | `grafana_address` | 0.0.0.0 | Address on which grafana listens |
 | `grafana_port` | 3000 | port on which grafana listens |
+| 'grafana_cap_net_bind_service' | false | Enables the use of ports below 1024 without root privilages by leveraging the 'capabilities' of the linux kernel. read: http://man7.org/linux/man-pages/man7/capabilities.7.html |
 | `grafana_url` | "http://{{ grafana_address }}:{{ grafana_port }}" | Full URL used to access Grafana from a web browser |
 | `grafana_api_url` | "{{ grafana_url }}" | URL used for API calls in provisioning if different from public URL. See [this issue](https://github.com/cloudalchemy/ansible-grafana/issues/70). |
 | `grafana_domain` | "{{ ansible_fqdn \| default(ansible_host) \| default('localhost') }}" | setting is only used in as a part of the `root_url` option. Useful when using GitHub or Google OAuth |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ grafana_data_dir: "/var/lib/grafana"
 
 grafana_address: "0.0.0.0"
 grafana_port: 3000
+# To enable the use of ports below 1024 for unprivileged processes linux needs to set CAP_NET_BIND_SERVICE.
+# This has some security implications, and should be a conscious choice.
+# Get informed by reading: http://man7.org/linux/man-pages/man7/capabilities.7.html
+grafana_cap_net_bind_service: false
 
 # External Grafana address. Variable maps to "root_url" in grafana server section
 grafana_url: "http://{{ grafana_address }}:{{ grafana_port }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,6 +47,15 @@
     - "{{ grafana_data_dir }}/dashboards"
     - "{{ grafana_data_dir }}/plugins"
 
+- name: Enable grafana to ports lowern then port 1024
+  capabilities:
+    path: /usr/sbin/grafana-server
+    capability: CAP_NET_BIND_SERVICE+ep
+    state: present
+  when:
+    - grafana_port <= 1024
+    - grafana_cap_net_bind_service 
+
 - name: Enable and start Grafana systemd unit
   systemd:
     name: grafana-server

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,14 +47,14 @@
     - "{{ grafana_data_dir }}/dashboards"
     - "{{ grafana_data_dir }}/plugins"
 
-- name: Enable grafana to ports lowern then port 1024
+- name: Enable grafana to ports lower than port 1024
   capabilities:
     path: /usr/sbin/grafana-server
     capability: CAP_NET_BIND_SERVICE+ep
     state: present
   when:
     - grafana_port <= 1024
-    - grafana_cap_net_bind_service 
+    - grafana_cap_net_bind_service
 
 - name: Enable and start Grafana systemd unit
   systemd:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -76,3 +76,10 @@
   when:
     - grafana_version != 'latest'
     - grafana_version is version_compare('5.0', '<')
+
+- name: Fail if grafana_port is lower then 1024 and grafana_cap_net_bind_service is not true
+  fail:
+    msg: Trying to use a port lower then 1024 without setting grafana_cap_net_bind_service.
+  when:
+    - grafana_port <= 1024
+    - not grafana_cap_net_bind_service

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -77,9 +77,9 @@
     - grafana_version != 'latest'
     - grafana_version is version_compare('5.0', '<')
 
-- name: Fail if grafana_port is lower then 1024 and grafana_cap_net_bind_service is not true
+- name: Fail if grafana_port is lower than 1024 and grafana_cap_net_bind_service is not true
   fail:
-    msg: Trying to use a port lower then 1024 without setting grafana_cap_net_bind_service.
+    msg: Trying to use a port lower than 1024 without setting grafana_cap_net_bind_service.
   when:
     - grafana_port <= 1024
     - not grafana_cap_net_bind_service


### PR DESCRIPTION
This patch enables the use of port lower then 1024 for grafana. This is achieved by setting the capability "CAP_NET_BIND_SERVICE" for the binary "/usr/sbin/grafana-server".
Setting this has some security implications but not a whole lot. The ping command on centos uses a similar approach to enable it to use raw packets while not using setuid.

Background:
Explaining the use of 'capabilities' for ping:
  - http://unixetc.co.uk/2016/05/30/linux-capabilities-and-ping/
Linux man page about 'capabilities':
  - http://man7.org/linux/man-pages/man7/capabilities.7.html