### PR TITLE
Fix apt error on Ubuntu 16.04

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,6 +56,7 @@
   package:
     name: "{{ grafana_package }}"
     state: "{{ (grafana_version == 'latest') | ternary('latest', 'present') }}"
+    allow_unauthenticated: yes
   register: _install_packages
   until: _install_packages is succeeded
   retries: 5


### PR DESCRIPTION
In Ubuntu 16.04 I faced an error while installing Grafana . 
```
fatal: []: FAILED! => {"cache_update_time": 1546944105, "cache_updated": true, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'grafana=3.1.1-*'' failed: E: There were unauthenticated packages and -y was used without --allow-unauthenticated\n", "rc": 100, "stderr":"E: There were unauthenticated packages and -y was used without --allow-unauthenticated\n", "stderr_lines": ["E: There were unauthenticated packages and -y was used without --allow-unauthenticated"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  grafana\n0 upgraded, 1newly installed, 0 to remove and 2 not upgraded.\nNeed to get 40.7 MB of archives.\nAfter this operation, 118 MB of additional disk space will be used.\nWARNING: The following packages cannot be authenticated!\n  grafana\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  grafana", "0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.", "Need to get 40.7 MB of archives.", "After this operation, 118 MB of additional disk spacewill be used.", "WARNING: The following packages cannot be authenticated!", "  grafana"]}
```
With this simple change it's fixed.