### PR TITLE
Become root to import dashboards

### DIFF
--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -159,6 +159,7 @@
   when: grafana_use_provisioning
 
 - name: Import grafana dashboards through provisioning
+  become: true
   synchronize:
     src: "/tmp/dashboards/"
     dest: "/var/lib/grafana/dashboards"


### PR DESCRIPTION
Currently Ansible fails to import local dashboards with permission denied error.

```
TASK [cloudalchemy.grafana : Import grafana dashboards through provisioning] **********************************************************
fatal: [grafana.dev1.box]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --checksum --recursive --rsh=/usr/bin/ssh -S none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null --no-motd --out-format=<<CHANGED>>%i %n%L /tmp/dashboards/ 10.10.10.13:/var/lib/grafana/dashboards", "msg": "Warning: Permanently added '10.10.10.13' (ECDSA) to the list of known hosts.\r\nrsync: mkstemp \"/var/lib/grafana/dashboards/.blackbox_overview_5345.json.XhXSUF\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.ceph_cluster_2842.json.9VNgk5\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.ceph_osd_5336.json.nhXLJu\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.ceph_pools_5342.json.XHEm9T\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.haproxy_detailed_2428.json.5OhZyj\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.junos_overview.json.V9WNYI\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.mysql_overview_7362.json.NVDGo8\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.node_detailed_1860.json.JZ1QOx\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.node_overview_159.json.ZysbgX\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.prometheus_overview_3662.json.ttjzHm\" failed: Permission denied (13)\nrsync: mkstemp \"/var/lib/grafana/dashboards/.rabbitmq_overview_4279.json.7HAY8L\" failed: Permission denied (13)\nrsync error: some files could not be transferred (code 23) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-52.200.1/rsync/main.c(996) [sender=2.6.9]\n", "rc": 23}
```
We can see that only `grafana` user has permissions to write to `/var/lib/grafana/dashboards/`, as expected.

```
nsmeds@grafana:~ $ ls -l /var/lib/grafana/
total 1716
drwxr-xr-x 1 grafana grafana     514 Jan 17 17:32 dashboards
-rw-r----- 1 grafana grafana 1757184 Jan 17 17:32 grafana.db
drwxr-xr-x 1 grafana grafana       0 Jan 17 17:32 plugins
drwx------ 1 grafana grafana       0 Jan 17 17:32 png
drwx------ 1 grafana grafana       2 Jan 17 17:32 sessions
```

Running this task as `root` resolves the issue.