### PR TITLE
Add `grafana_official_repo` vars for disable official repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
+| `grafana_official_repo` | true | Enable/Disable the official repository |
 | `grafana_use_provisioning` | true | Use Grafana provisioning capalibity when possible (**grafana_version=latest will assume >= 5.0**). |
 | `grafana_provisioning_synced` | false | Ensure no previously provisioned dashboards are kept if not referenced anymore. |
 | `grafana_system_user` | grafana | Grafana server system user |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+
+grafana_official_repo: true
 grafana_version: latest
 grafana_yum_repo_template: etc/yum.repos.d/grafana.repo.j2
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -26,7 +26,9 @@
     dest: "/etc/yum.repos.d/{{ grafana_yum_repo_template | basename | regex_replace('\\.j2$', '') }}"
     force: true
     backup: true
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when:
+    - ansible_pkg_mgr in ['yum', 'dnf']
+    - grafana_official_repo
 
 - block:
     - name: Import Grafana GPG signing key [Debian/Ubuntu]
@@ -50,6 +52,7 @@
       delay: 2
   when:
     - ansible_pkg_mgr == "apt"
+    - grafana_official_repo
   environment: "{{ grafana_environment }}"
 
 - name: Install Grafana


### PR DESCRIPTION
As the Private IaaS ops, I want to add `grafana_official_repo` variable,
so than I can use the internal repository, not offiaial.