### PR TITLE
Configure dashboard specific variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ grafana_dashboards:
   - dashboard_id: 111
     revision_id: 1
     datasource: prometheus
+    variables:
+      CUSTOM_VAR: 'value'
 ```
 Use a custom Grafana Yum repo template example:
 

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -99,6 +99,28 @@
   with_items: "{{ grafana_dashboards }}"
   when: grafana_dashboards | length > 0
 
+- name: Set custom variables in the dashboard
+  become: false
+  replace:
+    dest: "/tmp/dashboards/{{ item.dashboard_id }}.json"
+    regexp: '"(?:\${)(VAR_[A-Z0-9_-]+)(?:})"'
+    replace: '"{{ "{{" }} grafana_dashboards | selectattr("dashboard_id", "equalto", {{ item.dashboard_id }}) | map(attribute="variables.\1") | list | first {{ "}}" }}"'
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+  with_items: "{{ grafana_dashboards }}"
+  when: grafana_dashboards | length > 0
+
+- name: template local grafana dashboards
+  become: false
+  template:
+    src: "/tmp/dashboards/{{ item.dashboard_id }}.json"
+    dest: "/tmp/dashboards/{{ item.dashboard_id }}.json"
+  with_items: "{{ grafana_dashboards }}"
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+
 - name: copy local grafana dashboards
   become: false
   copy:

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -120,6 +120,8 @@
   delegate_to: localhost
   run_once: true
   changed_when: false
+  register: result
+  failed_when: not (result is success  or 'is undefined' in result.msg)
 
 - name: copy local grafana dashboards
   become: false


### PR DESCRIPTION
Example:
```
  - grafana_dashboards:
      - dashboard_id: 55
        revision_id: 3
        datasource: Graphite
        variables:
          VAR_PREFIX: 'prod.grafana'
```

Example done with Grafana Internal Stats dashboard:
- https://grafana.com/dashboards/55
- Relevant code: https://github.com/torkelo/dashboards/blob/master/grafana-internal-stats-graphite-version/internal_stats.json#L12

Resolves #131

How it works:
1. Replace ${VAR_*} with a Jinja templates
1. Execute template task on dashboards

I admit this is a little hackish. 😎 I tried to use some nested looping with Ansible, but that was asking a bit too much from Ansible.