### PR TITLE
Add optional SSL validation and private mirror for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_system_group` | grafana | Grafana server system group |
 | `grafana_version` | latest | Grafana package version |
 | `grafana_yum_repo_template` | etc/yum.repos.d/grafana.repo.j2 | Yum template to use |
+| `grafana_apt_repo` | `deb https://packages.grafana.com/oss/deb stable main` | Apt mirror to use (Debian/Ubuntu) |
+| `grafana_apt_repo_gpg_key_data` | `False` | GPG key value to use for apt mirror |
+| `grafana_apt_repo_gpg_key_url` | `https://packages.grafana.com/gpg.key` | URL to download GPG key to apt |
+| `grafana_apt_repo_gpg_key_url_validate_cert` | False | If TLS certificate validation needed at GPG key download time for apt |
 | `grafana_instance` | {{ ansible_fqdn \| default(ansible_host) \| default(inventory_hostname) }} | Grafana instance name |
 | `grafana_logs_dir` | /var/log/grafana | Path to logs directory |
 | `grafana_data_dir` | /var/lib/grafana | Path to database directory |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,22 @@
 ---
 grafana_version: latest
 grafana_yum_repo_template: etc/yum.repos.d/grafana.repo.j2
+grafana_apt_repo: deb https://packages.grafana.com/oss/deb stable main
+
+# Set to a value of GPG key for a private mirror
+# if set to non-false value, disables grafana_apt_gpg_key_url
+# example:
+# grafana_apt_repo_gpg_key_data: |
+#   -----BEGIN PGP PUBLIC KEY BLOCK-----
+#   Version: GnuPG v1.4.12 (GNU/Linux)
+#  mQENBFGs....
+#  ...
+#  =/2Mf
+# -----END PGP PUBLIC KEY BLOCK-----
+grafana_apt_repo_gpg_key_data: False
+
+grafana_apt_repo_gpg_key_url: https://packages.grafana.com/gpg.key
+grafana_apt_repo_gpg_key_url_validate_cert: false
 
 # Should we use the provisioning capability when possible (provisioning require grafana >= 5.0)
 grafana_use_provisioning: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ grafana_apt_repo: deb https://packages.grafana.com/oss/deb stable main
 #  ...
 #  =/2Mf
 # -----END PGP PUBLIC KEY BLOCK-----
-grafana_apt_repo_gpg_key_data: False
+grafana_apt_repo_gpg_key_data: false
 
 grafana_apt_repo_gpg_key_url: https://packages.grafana.com/gpg.key
 grafana_apt_repo_gpg_key_url_validate_cert: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,7 +39,7 @@
       until: _add_apt_key is succeeded
       retries: 5
       delay: 2
-      when: grafana_apt_repo_gpg_key_data == False
+      when: grafana_apt_repo_gpg_key_data
 
     - name: Import Grafana repo GPG signing key by value [Debian/Ubuntu]
       apt_key:
@@ -49,7 +49,7 @@
       until: _add_apt_key is succeeded
       retries: 5
       delay: 2
-      when: grafana_apt_repo_gpg_key_data != False
+      when: not grafana_apt_repo_gpg_key_data
 
     - name: Add Grafana repository [Debian/Ubuntu]
       apt_repository:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,20 +28,32 @@
     backup: true
   when: ansible_pkg_mgr in ['yum', 'dnf']
 
+# Debian/ubuntu installation from public mirror
 - block:
-    - name: Import Grafana GPG signing key [Debian/Ubuntu]
+    - name: Import Grafana repo GPG signing key by URL [Debian/Ubuntu]
       apt_key:
-        url: "https://packages.grafana.com/gpg.key"
+        url: '{{ grafana_apt_repo_gpg_key_url }}'
         state: present
-        validate_certs: false
+        validate_certs: '{{ grafana_apt_repo_gpg_key_url_validate_cert }}'
       register: _add_apt_key
       until: _add_apt_key is succeeded
       retries: 5
       delay: 2
+      when: grafana_apt_repo_gpg_key_data == False
+
+    - name: Import Grafana repo GPG signing key by value [Debian/Ubuntu]
+      apt_key:
+        data: '{{ grafana_apt_repo_gpg_key_data }}'
+        state: present
+      register: _add_apt_key
+      until: _add_apt_key is succeeded
+      retries: 5
+      delay: 2
+      when: grafana_apt_repo_gpg_key_data != False
 
     - name: Add Grafana repository [Debian/Ubuntu]
       apt_repository:
-        repo: deb https://packages.grafana.com/oss/deb stable main
+        repo: '{{ grafana_apt_repo }}'
         state: present
         update_cache: true
       register: _update_apt_cache


### PR DESCRIPTION
Add variable for apt key cert validation and private mirrors

* `grafana_apt_repo_gpg_key_url_validate_cert` (default to false)
   controls if TSL certificate for key will be validated.
   (preserves old behavior)
    
* Add support for private mirrors:
     - `grafana_apt_repo points` to the mirror (default value set to
         https://packages.grafana.com/oss/deb to preserve old behavior)
     - `grafana_apt_repo_gpg_key_url points` to gpg key to download
         (default value preserves old behavior)
     - `grafana_apt_repo_gpg_key_data` (default False, i.e. disabled)
         used to supply the gpg key directly as text from variable
