### PR TITLE
Allow to override enabled parameter in auth block

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,7 +86,8 @@ grafana_auth: {}
 #  ldap:
 #    config_file: "/etc/grafana/ldap.toml"
 #    allow_sign_up: false
-#  basic: true
+#  basic: 
+#    enabled: true
 
 grafana_ldap: {}
 #  verbose_logging: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,7 +86,7 @@ grafana_auth: {}
 #  ldap:
 #    config_file: "/etc/grafana/ldap.toml"
 #    allow_sign_up: false
-#  basic: 
+#  basic:
 #    enabled: true
 
 grafana_ldap: {}

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -19,7 +19,8 @@
       ldap:
         config_file: "/etc/grafana/ldap.toml"
         allow_sign_up: false
-      basic: true
+      basic:
+        enabled: true
     grafana_ldap:
       verbose_logging: false
       servers:

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -58,15 +58,13 @@ disable_login_form = {{ grafana_auth.disable_login_form | default('False') }}
 disable_signout_menu = {{ grafana_auth.disable_signout_menu | default('False') }}
 {%  for section, options in grafana_auth.items() %}
 {%    if section in ['disable_login_form', 'disable_signout_menu'] %}
-{%    elif section == 'basic' %}
-[auth.basic]
-enabled = True
 {%    else %}
 [auth.{{ section }}]
+{%      if "enabled" not in options %}
 enabled = True
+{%      endif %}
 {%      for k, v in options.items() %}
-{%        if k != 'enabled' %}{{ k }} = {{ v }}
-{%        endif %}
+{{ k }} = {{ v }}
 {%      endfor %}
 {%    endif %}
 {%  endfor %}


### PR DESCRIPTION
The current template forces `enabled` flag to always be True if the block is present.
While for most additional providers this works, however it makes it difficult to disable the `basic` provider as it's enabled by default. (for example when using auth proxy instead).

This PR allows passing `enabled` parameter to the auth sections. If missing, it will be set to True by default (for backwards compatibility with current config)

Example config:

```
 vars:
     grafana_auth:
       basic:
         enabled: false
       proxy:
         header_name: X-Forwarded-Email
         header_property: email
         auto_sign_up: true
```