### PR TITLE
Add tag `grafana_run` to give flexibility

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,7 @@
     name: grafana-server
     state: restarted
   tags:
-    - grafana_started
+    - grafana_run
 
 - name: Set privileges on provisioned dashboards
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,8 @@
   service:
     name: grafana-server
     state: restarted
+  tags:
+    - grafana_started
 
 - name: Set privileges on provisioned dashboards
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     - grafana_datasources
     - grafana_notifications
     - grafana_dashboards
-    - grafana_started
+    - grafana_run
 
 - name: Wait for grafana to start
   wait_for:
@@ -57,27 +57,27 @@
     - grafana_datasources
     - grafana_notifications
     - grafana_dashboards
-    - grafana_started
+    - grafana_run
 
 - include: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:
     - grafana_configure
-    - grafana_started
+    - grafana_run
 
 - include: datasources.yml
   when: grafana_datasources != []
   tags:
     - grafana_configure
     - grafana_datasources
-    - grafana_started
+    - grafana_run
 
 - include: notifications.yml
   when: grafana_alert_notifications | length > 0
   tags:
     - grafana_configure
     - grafana_notifications
-    - grafana_started
+    - grafana_run
 
 - name: "Check if there are any dashboards in {{ grafana_dashboards_dir }}"
   become: false
@@ -90,11 +90,11 @@
   tags:
     - grafana_configure
     - grafana_dashboards
-    - grafana_started
+    - grafana_run
 
 - include: dashboards.yml
   when: grafana_dashboards | length > 0 or found_dashboards.matched > 0
   tags:
     - grafana_configure
     - grafana_dashboards
-    - grafana_started
+    - grafana_run

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
     - grafana_datasources
     - grafana_notifications
     - grafana_dashboards
+    - grafana_started
 
 - name: Wait for grafana to start
   wait_for:
@@ -56,23 +57,27 @@
     - grafana_datasources
     - grafana_notifications
     - grafana_dashboards
+    - grafana_started
 
 - include: api_keys.yml
   when: grafana_api_keys | length > 0
   tags:
     - grafana_configure
+    - grafana_started
 
 - include: datasources.yml
   when: grafana_datasources != []
   tags:
     - grafana_configure
     - grafana_datasources
+    - grafana_started
 
 - include: notifications.yml
   when: grafana_alert_notifications | length > 0
   tags:
     - grafana_configure
     - grafana_notifications
+    - grafana_started
 
 - name: "Check if there are any dashboards in {{ grafana_dashboards_dir }}"
   become: false
@@ -85,9 +90,11 @@
   tags:
     - grafana_configure
     - grafana_dashboards
+    - grafana_started
 
 - include: dashboards.yml
   when: grafana_dashboards | length > 0 or found_dashboards.matched > 0
   tags:
     - grafana_configure
     - grafana_dashboards
+    - grafana_started


### PR DESCRIPTION
The intention was to give myself a `--skip-tags` target to prevent grafana-server from starting at all.

Reasoning: We use replacement variables in the configuration for different environments (i.e. dev, prod, etc.) and attempting to start grafana with those replacements blows up, as would be expected.

I'm relatively new to Ansible. Open to suggestions.