### PR TITLE
Add GnuPG2 as a dependency on Debian/Ubuntu 

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -5,3 +5,4 @@ grafana_dependencies:
   - adduser
   - ca-certificates
   - libfontconfig
+  - gnupg2


### PR DESCRIPTION
While installing Grafana, the GPG Key import might fail if gnupg2 is not installed.