### PR TITLE
Add support for serve_from_sub_path directive

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,10 @@ grafana_data_dir: "/var/lib/grafana"
 
 grafana_address: "0.0.0.0"
 grafana_port: 3000
+
+# If behind a reverse proxy and served on a subpath (e.g. /grafana) this should be set to True
+grafana_serve_from_sub_path = False
+
 # To enable the use of ports below 1024 for unprivileged processes linux needs to set CAP_NET_BIND_SERVICE.
 # This has some security implications, and should be a conscious choice.
 # Get informed by reading: http://man7.org/linux/man-pages/man7/capabilities.7.html

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -21,6 +21,7 @@ http_port = {{ grafana_port }}
 {% endif %}
 domain = {{ grafana_domain }}
 root_url = {{ grafana_url }}
+serve_from_sub_path = {{ grafana_serve_from_sub_path }}
 {% for k,v in grafana_server.items() %}
 {%   if not k in ['http_addr', 'http_port', 'domain', 'root_url'] %}
 {{ k }} = {{ v }}


### PR DESCRIPTION
Grafana 6.3 added support for 'serve_from_sub_path' in the grafana.ini to resolve a problem with serving behind a reverse proxy on a subpath. This adds support for it in the ansible config.