### PR TITLE
add default serve_from_sub_path option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ grafana_server:
   enable_gzip: false
   static_root_path: public
   router_logging: false
+  serve_from_sub_path: false
 
 # Variables correspond to ones in grafana.ini configuration file
 # Security


### PR DESCRIPTION
This option wasn't specified by default and as mentioned in #162 it is now added to Grafana 6.3.

Closes #162