### PR TITLE
add ansible_remote_cache

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,9 @@ grafana_database:
 #  max_open_conn: ""
 #  log_queries: ""
 
+# Remote cache
+grafana_remote_cache: {}
+
 # User management and registration
 grafana_welcome_email_on_sign_up: false
 grafana_users:

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -37,6 +37,12 @@ root_url = {{ grafana_url }}
 {%   endif %}
 {% endfor %}
 
+# Remote cache
+[remote_cache]
+{% for k,v in grafana_remote_cache.items() %}
+{{ k }} = {{ v }}
+{% endfor %}
+
 # Security
 [security]
 {% for k,v in grafana_security.items() %}


### PR DESCRIPTION
Ansible has a newish config section named [remote_cache] that replaces [session].  I'm in the process of configuring my grafana servers to use redis as the cache server instead of the database and need a method of configuring this through the ansible-grafana role.

See https://github.com/cloudalchemy/ansible-grafana/issues/155