### PR TITLE
Using tests as filters is deprecated. Changed to "result is search".

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -54,7 +54,7 @@
     msg: "Check server configuration. Please look at http://docs.grafana.org/installation/configuration/#server"
   when:
     - grafana_server.root_url is defined
-    - grafana_server.root_url | search(grafana_server.domain)
+    - grafana_server.root_url is search(grafana_server.domain)
 
 - name: Fail when grafana_api_keys uses invalid role names
   fail:


### PR DESCRIPTION
small change because of following warning: 
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|search` use `result is search`. This feature will be removed in version 2.9.