### PR TITLE
Database, user and password attributes for grafana_datasource (API)

### DIFF
--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -11,6 +11,9 @@
     is_default: "{{ item.isDefault | default(omit) }}"
     basic_auth_user: "{{ item.basicAuthUser | default(omit) }}"
     basic_auth_password: "{{ item.basicAuthPassword | default(omit) }}"
+    database: "{{ item.database | default(omit) }}"
+    user: "{{ item.user | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
   with_items: "{{ grafana_datasources }}"
   when: not grafana_use_provisioning
 


### PR DESCRIPTION
Passing `database`, `user` and `password` attributes to grafana_datasource (API method) in order to be able to manage influxdb/mysql Data Sources through Grafana API. This diff was tested provisioning both Data Sources.

It fixes issue #181.