### PR TITLE
Add missing provisioning directories

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,6 +10,8 @@
     - "/etc/grafana/datasources"
     - "/etc/grafana/provisioning"
     - "/etc/grafana/provisioning/datasources"
+    - "/etc/grafana/provisioning/dashboards"
+    - "/etc/grafana/provisioning/notifiers"
 
 - name: Create grafana main configuration file
   template:


### PR DESCRIPTION
Folders provisioning/dashboards and provisioning/notifiers should also exist, as per https://grafana.com/docs/administration/provisioning/