### PR TITLE
Adding the ability to manage [panels] session

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -245,3 +245,8 @@ grafana_api_keys: []
 grafana_api_keys_dir: "{{ lookup('env', 'HOME') }}/grafana/keys"
 
 grafana_environment: {}
+
+# Panels configurations
+grafana_panels: {}
+#  disable_sanitize_html: false
+#  enable_alpha: false

--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -14,6 +14,12 @@
     database: "{{ item.database | default(omit) }}"
     user: "{{ item.user | default(omit) }}"
     password: "{{ item.password | default(omit) }}"
+    aws_auth_type: "{{ item.aws_auth_type | default(omit) }}"
+    aws_default_region: "{{ item.aws_default_region | default(omit) }}"
+    aws_access_key: "{{ item.aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ item.aws_secret_key | default(omit) }}"
+    aws_credentials_profile: "{{ item.aws_credentials_profile | default(omit) }}"
+    aws_custom_metrics_namespaces: "{{ item.aws_custom_metrics_namespaces | default(omit) }}"
   with_items: "{{ grafana_datasources }}"
   when: not grafana_use_provisioning
 

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -178,3 +178,11 @@ provider = {{ grafana_image_storage.provider }}
 {%     endif %}
 {%   endfor %}
 {% endif %}
+
+# Panels
+{% if grafana_panels != {} %}
+[panels]
+{%   for k,v in grafana_panels.items() %}
+{{ k }} = {{ v }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
Since version 6.0 Grafana sanitises HTMLs by default. To get around of it, a new `[panels]` session was created to hold `disable_sanitize_html` option (and eventually others related to panels).

With this patch we are adding the option to manage this section of `/etc/grafana/grafana.ini` file.

[1] - https://grafana.com/docs/installation/configuration/#disable-sanitize-html