### PR TITLE
Allow firewall port to be opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_data_dir` | /var/lib/grafana | Path to database directory |
 | `grafana_address` | 0.0.0.0 | Address on which grafana listens |
 | `grafana_port` | 3000 | port on which grafana listens |
+| `grafana_open_firewall` | false | Open port in firewall |
 | `grafana_cap_net_bind_service` | false | Enables the use of ports below 1024 without root privilages by leveraging the 'capabilities' of the linux kernel. read: http://man7.org/linux/man-pages/man7/capabilities.7.html |
 | `grafana_url` | "http://{{ grafana_address }}:{{ grafana_port }}" | Full URL used to access Grafana from a web browser |
 | `grafana_api_url` | "{{ grafana_url }}" | URL used for API calls in provisioning if different from public URL. See [this issue](https://github.com/cloudalchemy/ansible-grafana/issues/70). |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ grafana_port: 3000
 # This has some security implications, and should be a conscious choice.
 # Get informed by reading: http://man7.org/linux/man-pages/man7/capabilities.7.html
 grafana_cap_net_bind_service: false
+grafana_open_firewall: false
 
 # External Grafana address. Variable maps to "root_url" in grafana server section
 grafana_url: "http://{{ grafana_address }}:{{ grafana_port }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -78,6 +78,14 @@
     - grafana_port <= 1024
     - grafana_cap_net_bind_service
 
+- name: Open Grafana port in Firewall
+  firewalld:
+    port: "{{ grafana_port }}/tcp"
+    immediate: yes
+    permanent: yes
+    state: enabled
+  when: grafana_open_firewall|bool
+
 - name: Enable and start Grafana systemd unit
   systemd:
     name: grafana-server


### PR DESCRIPTION
Role did not allow for firewalld port to be opened for Grafana service. Default of false maintains this behavior.