### PR TITLE
WIP: BREAKING CHANGE: use ansible module to manage dashboards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE=2.7
-  - ANSIBLE=2.8
-  - ANSIBLE=2.9
+  - ANSIBLE=2.10
 install:
   - pip3 install tox-travis git-semver
 script:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provision and manage [grafana](https://github.com/grafana/grafana) - platform fo
 
 ## Requirements
 
-- Ansible >= 2.7 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.10 (It might work on previous versions, but we cannot guarantee it)
 - libselinux-python on deployer host (only when deployer machine has SELinux)
 - grafana >= 5.1 (for older grafana versions use this role in version 0.10.1 or earlier)
 - jmespath on deployer machine. If you are using Ansible from a Python virtualenv, install *jmespath* to the same virtualenv via pip.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `grafana_use_provisioning` | true | Use Grafana provisioning capability when possible (**grafana_version=latest will assume >= 5.0**). |
-| `grafana_provisioning_synced` | false | Ensure no previously provisioned dashboards are kept if not referenced anymore. |
 | `grafana_system_user` | grafana | Grafana server system user |
 | `grafana_system_group` | grafana | Grafana server system group |
 | `grafana_version` | latest | Grafana package version |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,12 +2,6 @@
 grafana_version: latest
 grafana_yum_repo_template: etc/yum.repos.d/grafana.repo.j2
 
-# Should we use the provisioning capability when possible (provisioning require grafana >= 5.0)
-grafana_use_provisioning: true
-
-# Should the provisioning be kept synced. If true, previous provisioned objects will be removed if not referenced anymore.
-grafana_provisioning_synced: false
-
 grafana_instance: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
 
 grafana_logs_dir: "/var/log/grafana"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Grafana - platform for analytics and monitoring
   license: MIT
   company: none
-  min_ansible_version: 2.7
+  min_ansible_version: 2.10
   platforms:
     - name: Ubuntu
       versions:

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -4,12 +4,13 @@
   roles:
     - ansible-grafana
   vars:
-    grafana_version: 6.2.5
+    grafana_version: 6.7.2
     grafana_yum_repo_template: alternative.grafana.yum.repo.j2
+    grafana_address: 127.0.0.1
+    grafana_port: 4000
     grafana_security:
       admin_user: admin
       admin_password: "password"
-    grafana_address: "127.0.0.1"
     grafana_auth:
       disable_login_form: false
       oauth_auto_login: false
@@ -77,26 +78,6 @@
         isDefault: true
         settings:
           addresses: "example@example.com"
-    grafana_dashboards:
-      - dashboard_id: '1860'
-        revision_id: '4'
-        datasource: 'Prometheus'
-      - dashboard_id: '358'
-        revision_id: '1'
-        datasource: 'Prometheus'
-    grafana_datasources:
-      - name: "Prometheus"
-        type: "prometheus"
-        access: "proxy"
-        url: "http://prometheus.mydomain"
-        basicAuth: true
-        basicAuthUser: "admin"
-        basicAuthPassword: "password"
-        isDefault: true
-        jsonData:
-          tlsAuth: false
-          tlsAuthWithCACert: false
-          tlsSkipVerify: true
     grafana_log:
       mode: syslog
       level: warn

--- a/molecule/alternative/tests/test_alternative.py
+++ b/molecule/alternative/tests/test_alternative.py
@@ -37,11 +37,11 @@ def test_service(host):
 def test_packages(host):
     p = host.package("grafana")
     assert p.is_installed
-    assert p.version == "6.2.5"
+    assert p.version == "6.7.2"
 
 
 def test_socket(host):
-    assert host.socket("tcp://127.0.0.1:3000").is_listening
+    assert host.socket("tcp://127.0.0.1:4000").is_listening
 
 
 def test_alternative_yum_repo(host):

--- a/molecule/dashboards/molecule.yml
+++ b/molecule/dashboards/molecule.yml
@@ -1,0 +1,38 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: bionic
+    image: quay.io/paulfantom/molecule-systemd:ubuntu-18.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    published_ports:
+      - 3000:3000
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - python3
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    create: ../default/create.yml
+    prepare: prepare.yml
+    converge: playbook.yml
+    destroy: ../default/destroy.yml
+  inventory:
+    group_vars:
+      python3:
+        ansible_python_interpreter: /usr/bin/python3
+scenario:
+  name: dashboards
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    enabled: true

--- a/molecule/dashboards/playbook.yml
+++ b/molecule/dashboards/playbook.yml
@@ -1,0 +1,31 @@
+---
+- hosts: all
+  any_errors_fatal: true
+  roles:
+    - ansible-grafana
+  collections:
+    - community.grafana
+  vars:
+    grafana_security:
+      admin_user: admin
+      admin_password: "password"
+    grafana_dashboards:
+      - dashboard_id: '1860'
+        revision_id: '4'
+        datasource: 'Prometheus'
+      - dashboard_id: '358'
+        revision_id: '1'
+        datasource: 'Prometheus'
+    grafana_datasources:
+      - name: "Prometheus"
+        type: "prometheus"
+        access: "proxy"
+        url: "http://prometheus.mydomain"
+        basicAuth: true
+        basicAuthUser: "admin"
+        basicAuthPassword: "password"
+        isDefault: true
+        jsonData:
+          tlsAuth: false
+          tlsAuthWithCACert: false
+          tlsSkipVerify: true

--- a/molecule/dashboards/prepare.yml
+++ b/molecule/dashboards/prepare.yml
@@ -1,0 +1,5 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks: []

--- a/molecule/dashboards/tests/test_dashboards.py
+++ b/molecule/dashboards/tests/test_dashboards.py
@@ -1,0 +1,15 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_service(host):
+    s = host.service("grafana-server")
+    # assert s.is_enabled
+    assert s.is_running
+
+
+def test_socket(host):
+    assert host.socket("tcp://127.0.0.1:3000").is_listening

--- a/tasks/api_keys.yml
+++ b/tasks/api_keys.yml
@@ -1,10 +1,8 @@
 ---
 - name: Ensure grafana key directory exists
-  become: false
   file:
     path: "{{ grafana_api_keys_dir }}/{{ inventory_hostname }}"
     state: directory
-  delegate_to: localhost
 
 - name: Check api key list
   uri:
@@ -31,11 +29,9 @@
   register: new_api_keys
 
 - name: Create api keys file to allow the keys to be seen and used by other automation
-  become: false
   copy:
     dest: "{{ grafana_api_keys_dir }}/{{ inventory_hostname }}/{{ item['item']['name'] }}.key"
     content: "{{ item['json']['key'] }}"
     backup: false
   when: item['json'] is defined
   with_items: "{{ new_api_keys['results'] }}"
-  delegate_to: localhost

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,11 +3,10 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: root
-    group: grafana
+    # owner: root
+    # group: grafana
   with_items:
     - "/etc/grafana"
-    - "/etc/grafana/datasources"
     - "/etc/grafana/provisioning"
     - "/etc/grafana/provisioning/datasources"
     - "/etc/grafana/provisioning/dashboards"

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -71,91 +71,16 @@
       with_items: "{{ grafana_dashboards }}"
       when: grafana_dashboards | length > 0
 
-- name: Import grafana dashboards through API
-  uri:
-    url: "{{ grafana_api_url }}/api/dashboards/db"
-    user: "{{ grafana_security.admin_user }}"
-    password: "{{ grafana_security.admin_password }}"
-    force_basic_auth: true
-    method: POST
-    body_format: json
-    body: >
-      {
-        "dashboard": {{ lookup("file", item) }},
-        "overwrite": true,
-        "message": "Updated by ansible"
-      }
+- name: import grafana dashboards
+  grafana_dashboard:
+    grafana_url: "{{ grafana_api_url }}"
+    grafana_user: "{{ grafana_security.admin_user }}"
+    grafana_password: "{{ grafana_security.admin_password }}"
+    path: "{{ _tmp_dashboards.path }}/{{ item }}"
+    message: Updated by ansible
+    state: present
+    overwrite: true
   no_log: true
   with_fileglob:
     - "{{ _tmp_dashboards.path }}/*"
     - "{{ grafana_dashboards_dir }}/*.json"
-  when: not grafana_use_provisioning
-
-# TODO: uncomment this when ansible 2.7 will be min supported version
-# - name: import grafana dashboards
-#   grafana_dashboard:
-#     grafana_url: "{{ grafana_api_url }}"
-#     grafana_user: "{{ grafana_security.admin_user }}"
-#     grafana_password: "{{ grafana_security.admin_password }}"
-#     path: "/tmp/dashboards/{{ item }}"
-#     message: Updated by ansible
-#     state: present
-#     overwrite: true
-#   no_log: true
-#   with_fileglob:
-#     - "/tmp/dashboards/*"
-
-- when: grafana_use_provisioning
-  block:
-    - name: Create/Update dashboards file (provisioning)
-      become: true
-      copy:
-        dest: "/etc/grafana/provisioning/dashboards/ansible.yml"
-        content: |
-          apiVersion: 1
-          providers:
-           - name: 'default'
-             orgId: 1
-             folder: ''
-             type: file
-             options:
-               path: "{{ grafana_data_dir }}/dashboards"
-        backup: false
-        owner: root
-        group: grafana
-        mode: 0640
-      notify: restart grafana
-
-    - name: Register previously copied dashboards
-      find:
-        paths: "{{ grafana_data_dir }}/dashboards"
-        hidden: true
-        patterns:
-          - "*.json"
-      register: _dashboards_present
-      when: grafana_provisioning_synced
-
-    - name: Import grafana dashboards
-      become: true
-      copy:
-        src: "{{ item }}"
-        dest: "{{ grafana_data_dir }}/dashboards/{{ item | basename }}"
-      with_fileglob:
-        - "{{ _tmp_dashboards.path }}/*"
-        - "{{ grafana_dashboards_dir }}/*.json"
-      register: _dashboards_copied
-      notify: "provisioned dashboards changed"
-
-    - name: Get dashboard lists
-      set_fact:
-        _dashboards_present_list: "{{ _dashboards_present | json_query('files[*].path') | default([]) }}"
-        _dashboards_copied_list: "{{ _dashboards_copied | json_query('results[*].dest') | default([]) }}"
-      when: grafana_provisioning_synced
-
-    - name: Remove dashbards not present on deployer machine (synchronize)
-      become: true
-      file:
-        path: "{{ item }}"
-        state: absent
-      with_items: "{{ _dashboards_present_list | difference( _dashboards_copied_list ) }}"
-      when: grafana_provisioning_synced

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -1,86 +1,83 @@
 ---
-- become: false
-  delegate_to: localhost
-  run_once: true
-  block:
-    - name: Create local grafana dashboard directory
-      tempfile:
-        state: directory
-      register: _tmp_dashboards
-      changed_when: false
-      check_mode: false
+- name: Create local grafana dashboard directory
+  tempfile:
+    state: directory
+  register: _tmp_dashboards
+  changed_when: false
+  check_mode: false
 
-    # Use curl to solve issue #77
-    - name: download grafana dashboard from grafana.net to local directory
-      command: >
-        curl --fail --compressed
-        https://grafana.com/api/dashboards/{{ item.dashboard_id }}/revisions/{{ item.revision_id }}/download
-        -o {{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json
-      args:
-        creates: "{{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json"
-        warn: false
-      register: _download_dashboards
-      until: _download_dashboards is succeeded
-      retries: 5
-      delay: 2
-      with_items: "{{ grafana_dashboards }}"
-      when: grafana_dashboards | length > 0
-      changed_when: false
-      check_mode: false
-      tags:
-        - skip_ansible_lint
+# Use curl to solve issue #77
+- name: download grafana dashboard from grafana.net to local directory
+  command: >
+    curl --fail --compressed
+    https://grafana.com/api/dashboards/{{ item.dashboard_id }}/revisions/{{ item.revision_id }}/download
+    -o {{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json
+  args:
+    creates: "{{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json"
+    warn: false
+  register: _download_dashboards
+  until: _download_dashboards is succeeded
+  retries: 5
+  delay: 2
+  with_items: "{{ grafana_dashboards }}"
+  when: grafana_dashboards | length > 0
+  changed_when: false
+  check_mode: false
+  tags:
+    - skip_ansible_lint
 
-    # As noted in [1] an exported dashboard replaces the exporter's datasource
-    # name with a representative name, something like 'DS_GRAPHITE'. The name
-    # is different for each datasource plugin, but always begins with 'DS_'.
-    # In the rest of the data, the same name is used, but captured in braces,
-    # for example: '${DS_GRAPHITE}'.
-    #
-    # [1] http://docs.grafana.org/reference/export_import/#import-sharing-with-grafana-2-x-or-3-0
-    #
-    # The data structure looks (massively abbreviated) something like:
-    #
-    #   "name": "DS_GRAPHITE",
-    #   "datasource": "${DS_GRAPHITE}",
-    #
-    # If we import the downloaded dashboard verbatim, it will not automatically
-    # be connected to the data source like we want it. The Grafana UI expects
-    # us to do the final connection by hand, which we do not want to do.
-    # So, in the below task we ensure that we replace instances of this string
-    # with the data source name we want.
-    # To make sure that we're not being too greedy with the regex replacement
-    # of the data source to use for each dashboard that's uploaded, we make the
-    # regex match very specific by using the following:
-    #
-    # 1. Literal boundaries for " on either side of the match.
-    # 2. Non-capturing optional group matches for the ${} bits which may, or
-    #    or may not, be there..
-    # 3. A case-sensitive literal match for DS .
-    # 4. A one-or-more case-sensitive match for the part that follows the
-    #    underscore, with only A-Z, 0-9 and - or _ allowed.
-    #
-    # This regex can be tested and understood better by looking at the
-    # matches and non-matches in https://regex101.com/r/f4Gkvg/6
+# As noted in [1] an exported dashboard replaces the exporter's datasource
+# name with a representative name, something like 'DS_GRAPHITE'. The name
+# is different for each datasource plugin, but always begins with 'DS_'.
+# In the rest of the data, the same name is used, but captured in braces,
+# for example: '${DS_GRAPHITE}'.
+#
+# [1] http://docs.grafana.org/reference/export_import/#import-sharing-with-grafana-2-x-or-3-0
+#
+# The data structure looks (massively abbreviated) something like:
+#
+#   "name": "DS_GRAPHITE",
+#   "datasource": "${DS_GRAPHITE}",
+#
+# If we import the downloaded dashboard verbatim, it will not automatically
+# be connected to the data source like we want it. The Grafana UI expects
+# us to do the final connection by hand, which we do not want to do.
+# So, in the below task we ensure that we replace instances of this string
+# with the data source name we want.
+# To make sure that we're not being too greedy with the regex replacement
+# of the data source to use for each dashboard that's uploaded, we make the
+# regex match very specific by using the following:
+#
+# 1. Literal boundaries for " on either side of the match.
+# 2. Non-capturing optional group matches for the ${} bits which may, or
+#    or may not, be there..
+# 3. A case-sensitive literal match for DS .
+# 4. A one-or-more case-sensitive match for the part that follows the
+#    underscore, with only A-Z, 0-9 and - or _ allowed.
+#
+# This regex can be tested and understood better by looking at the
+# matches and non-matches in https://regex101.com/r/f4Gkvg/6
 
-    - name: Set the correct data source name in the dashboard
-      replace:
-        dest: "{{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json"
-        regexp: '"(?:\${)?DS_[A-Z0-9_-]+(?:})?"'
-        replace: '"{{ item.datasource }}"'
-      changed_when: false
-      with_items: "{{ grafana_dashboards }}"
-      when: grafana_dashboards | length > 0
+- name: Set the correct data source name in the dashboard
+  replace:
+    dest: "{{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json"
+    regexp: '"(?:\${)?DS_[A-Z0-9_-]+(?:})?"'
+    replace: '"{{ item.datasource }}"'
+  changed_when: false
+  with_items: "{{ grafana_dashboards }}"
+  when: grafana_dashboards | length > 0
 
 - name: import grafana dashboards
-  grafana_dashboard:
+  community.grafana.grafana_dashboard:
+    # grafana_dashboard:
     grafana_url: "{{ grafana_api_url }}"
     grafana_user: "{{ grafana_security.admin_user }}"
     grafana_password: "{{ grafana_security.admin_password }}"
-    path: "{{ _tmp_dashboards.path }}/{{ item }}"
-    message: Updated by ansible
+    path: "{{ item }}"
+    commit_message: Updated by ansible
     state: present
-    overwrite: true
-  no_log: true
+    # overwrite: true
+  # no_log: true
   with_fileglob:
     - "{{ _tmp_dashboards.path }}/*"
     - "{{ grafana_dashboards_dir }}/*.json"

--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -21,20 +21,3 @@
     aws_credentials_profile: "{{ item.aws_credentials_profile | default(omit) }}"
     aws_custom_metrics_namespaces: "{{ item.aws_custom_metrics_namespaces | default(omit) }}"
   with_items: "{{ grafana_datasources }}"
-  when: not grafana_use_provisioning
-
-- name: Create/Update datasources file (provisioning)
-  become: true
-  copy:
-    dest: "/etc/grafana/provisioning/datasources/ansible.yml"
-    content: |
-      apiVersion: 1
-      deleteDatasources: []
-      datasources:
-      {{ grafana_datasources | to_nice_yaml }}
-    backup: false
-    owner: root
-    group: grafana
-    mode: 0640
-  notify: restart grafana
-  when: grafana_use_provisioning

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,4 @@
 ---
-
 - block:
     - name: Update apt cache
       apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,12 +73,16 @@
     - grafana_run
 
 - include: api_keys.yml
+  become: false
+  delegate_to: localhost
   when: grafana_api_keys | length > 0
   tags:
     - grafana_configure
     - grafana_run
 
 - include: datasources.yml
+  become: false
+  delegate_to: localhost
   when: grafana_datasources != []
   tags:
     - grafana_configure
@@ -86,6 +90,8 @@
     - grafana_run
 
 - include: notifications.yml
+  become: false
+  delegate_to: localhost
   when: grafana_alert_notifications | length > 0
   tags:
     - grafana_configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,8 @@
     - grafana_run
 
 - include: dashboards.yml
+  delegate_to: localhost
+  become: false
   when: grafana_dashboards | length > 0 or found_dashboards | length > 0
   tags:
     - grafana_configure

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -18,3 +18,13 @@
   delay: 2
   notify:
     - restart grafana
+
+# - name: Install plugins
+#   become: true
+#   grafana_plugins:
+#     name: "{{ item }}"
+#     version: "{{ latest }}"
+#     state: present
+#   with_items: "{{ grafana_plugins }}"
+#   notify:
+#     - restart grafana

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -63,13 +63,6 @@
     - "'ldap' in grafana_auth"
     - grafana_ldap is not defined or ('servers' not in grafana_ldap or 'group_mappings' not in grafana_ldap)
 
-- name: Force grafana_use_provisioning to false if grafana_version is < 5.0 ( grafana_version is set to '{{ grafana_version }}' )
-  set_fact:
-    grafana_use_provisioning: false
-  when:
-    - grafana_version != 'latest'
-    - grafana_version is version_compare('5.0', '<')
-
 - name: Fail if grafana_port is lower than 1024 and grafana_cap_net_bind_service is not true
   fail:
     msg: Trying to use a port lower than 1024 without setting grafana_cap_net_bind_service.


### PR DESCRIPTION
Rely on ansible `grafana_dashboards` module to manage dashboards instead of current workaround.