### PR TITLE
[minor] [feature] Grafana dashboard provisioner config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
+| `grafana_dashboards_provider_config` | { disableDeletion: false, editable: true, updateIntervalSeconds: 10, allowUiUpdates: false } | The dashboard provider configuration |
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |
 | `grafana_plugins` | [] |  List of Grafana plugins which should be installed |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,6 +207,12 @@ grafana_dashboards: []
 #    revision_id: '1'
 #    datasource: 'Prometheus'
 
+grafana_dashboards_provider_config: 
+  disableDeletion: false
+  editable: true
+  updateIntervalSeconds: 10
+  allowUiUpdates: false
+
 grafana_dashboards_dir: "dashboards"
 
 # Alert notification channels to configure

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,7 +207,7 @@ grafana_dashboards: []
 #    revision_id: '1'
 #    datasource: 'Prometheus'
 
-grafana_dashboards_provider_config: 
+grafana_dashboards_provider_config:
   disableDeletion: false
   editable: true
   updateIntervalSeconds: 10

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -118,6 +118,7 @@
              orgId: 1
              folder: ''
              type: file
+             {{ grafana_dashboards_provider_config | to_nice_yaml(indent=3) | trim | indent(3) }}
              options:
                path: "{{ grafana_data_dir }}/dashboards"
         backup: false


### PR DESCRIPTION
Hi,
I added a way of configuring the default (and only) dashboard provisioner. This may cover some cases where the UI changes to provisioned dashboards are welcome, or wether we want to prevent edits or deletions.

The default role values are taken from [the Grafana defaults](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards); I included only the parameters not actually present in the configuration to avoid possible breaking changes.

Doc is there, but I couldn't think of a suitable test; we tried it in our deploy pipeline and it works fine.