### PR TITLE
[fix] Update apt-cache before installing dependencies

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,12 @@
 ---
+- name: Update apt cache
+  apt:
+    update_cache: true
+  register: _pre_update_apt_cache
+  until: _pre_update_apt_cache is succeeded
+  when:
+    - ansible_pkg_mgr == "apt"
+
 - name: Install dependencies
   package:
     name: "{{ grafana_dependencies }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,20 +1,22 @@
 ---
-- name: Update apt cache
-  apt:
-    update_cache: true
-  register: _pre_update_apt_cache
-  until: _pre_update_apt_cache is succeeded
-  when:
-    - ansible_pkg_mgr == "apt"
 
-- name: Install dependencies
-  package:
-    name: "{{ grafana_dependencies }}"
-    state: present
-  register: _install_dep_packages
-  until: _install_dep_packages is succeeded
-  retries: 5
-  delay: 2
+- block:
+    - name: Update apt cache
+      apt:
+        update_cache: true
+      register: _pre_update_apt_cache
+      until: _pre_update_apt_cache is succeeded
+      when:
+        - ansible_pkg_mgr == "apt"
+
+    - name: Install dependencies
+      package:
+        name: "{{ grafana_dependencies }}"
+        state: present
+      register: _install_dep_packages
+      until: _install_dep_packages is succeeded
+      retries: 5
+      delay: 2
 
 - name: Remove conflicting grafana packages
   package:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-molecule>=2.15.0
+molecule>=2.15.0,<3.0.0
 docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0


### PR DESCRIPTION
Updates the apt cache before installing Grafana dependencies
through the package manager. This resolves a bug where old dependencies,
or those with a changed name, would not be installed due to
the package manager not being able to find them.

Fixes #200 
Ref #201 