### PR TITLE
Avoid being clever about unsupported architectures

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -6,13 +6,6 @@
       - grafana_database is mapping
       - grafana_security is mapping
 
-- name: Fail on unsupported system architectures
-  fail:
-    msg: "Sorry grafana doesn't support {{ ansible_architecture }} on this OS family ({{ ansible_os_family }}). Exiting."
-  when:
-    - ansible_architecture != "x86_64"
-    - not ( ansible_architecture in ['armv6l', 'armv7l'] and ansible_os_family == 'Debian' )
-
 - name: Fail when datasources aren't configured when dashboards are set to be installed
   fail:
     msg: "You need to specify datasources for dashboards!!!"


### PR DESCRIPTION
Previously, when different packages sources where used to install Grafana,
it made sense to fail fast, if there where no supported package. But now
Grafana supports many architecture directly and this pre-flight check
hinders installation on aarch64. Removing this check, delegating the
failure to the package installer, simplifies the installation.