### PR TITLE
Make it possible to configure the folder of imported dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
+| `grafana_dashboards_folder` | "" | Name of the Grafana folder where dashboards should be imported |
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |
 | `grafana_plugins` | [] |  List of Grafana plugins which should be installed |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -209,6 +209,8 @@ grafana_dashboards: []
 
 grafana_dashboards_dir: "dashboards"
 
+grafana_dashboards_folder: ""
+
 # Alert notification channels to configure
 grafana_alert_notifications: []
 #   - name: "Email Alert"

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -116,7 +116,7 @@
           providers:
            - name: 'default'
              orgId: 1
-             folder: ''
+             folder: "{{ grafana_dashboards_folder }}"
              type: file
              options:
                path: "{{ grafana_data_dir }}/dashboards"


### PR DESCRIPTION
Dashboards are currently always imported to the root folder in Grafana. I'd like to change that.