### PR TITLE
Added ability to update or remove plugins

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -6,15 +6,23 @@
     paths: "{{ grafana_data_dir }}/plugins"
   register: installed_plugins
 
-- name: Install plugins
+- name: Remove unwanted plugins
   become: true
-  command: "grafana-cli --pluginsDir {{ grafana_data_dir }}/plugins plugins install {{ item }}"
-  args:
-    creates: "{{ grafana_data_dir }}/plugins/{{ item }}"
-  with_items: "{{ grafana_plugins | difference(installed_plugins.files) }}"
-  register: _plugin_install
-  until: _plugin_install is succeeded
-  retries: 5
-  delay: 2
+  grafana_plugin:
+    grafana_plugins_dir: "{{ grafana_data_dir }}/plugins"
+    name: "{{ item.path | basename }}"
+    state: absent
+  when: item.path | basename  not in grafana_plugins
+  with_items: "{{ installed_plugins.files }}"
+  notify:
+    - restart grafana
+
+- name: Make sure plugins are installed and updated
+  become: true
+  grafana_plugin:
+    grafana_plugins_dir: "{{ grafana_data_dir }}/plugins"
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ grafana_plugins }}"
   notify:
     - restart grafana


### PR DESCRIPTION
This solves https://github.com/cloudalchemy/ansible-grafana/issues/215

It removes unwanted plugins and install&update to latest(which is default of underlaying module). 

If we wanted to specify module version and don't update by default, we would need to make breaking changes to _grafana_plugins_ variable, which I didn't wanted to make.