### PR TITLE
Cleaner and more general handling of auth options

### DIFF
--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -67,8 +67,7 @@ oauth_auto_login = {{ grafana_auth.oauth_auto_login | default('False') }}
 disable_signout_menu = {{ grafana_auth.disable_signout_menu | default('False') }}
 signout_redirect_url = {{ grafana_auth.signout_redirect_url | default('') }}
 {%  for section, options in grafana_auth.items() %}
-{%    if section in ['disable_login_form', 'oauth_auto_login', 'disable_signout_menu', 'signout_redirect_url'] %}
-{%    else %}
+{%    if options is mapping %}
 [auth.{{ section }}]
 {%      if "enabled" not in options %}
 enabled = True
@@ -76,6 +75,7 @@ enabled = True
 {%      for k, v in options.items() %}
 {{ k }} = {{ v }}
 {%      endfor %}
+{%    else %}
 {%    endif %}
 {%  endfor %}
 {% endif %}


### PR DESCRIPTION
Before this change, the keys of grafana_auth's value were tested for a
static list of names like 'disable_login_form'. If they didn't match it
would suppose they're a mapping and thus descent into it.
This would work as long as the key was in the list, but for example
using 'login_maximum_inactive_lifetime_days' would fail as it's not a
hash, but it is a valid grafana option.

This change makes the test more elegant, robust and easier to maintain.

Fixes #218