### PR TITLE
Fix custom auth option not showing up

### DIFF
--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -76,6 +76,7 @@ enabled = True
 {{ k }} = {{ v }}
 {%      endfor %}
 {%    else %}
+{{ section }} = {{ options }}
 {%    endif %}
 {%  endfor %}
 {% endif %}


### PR DESCRIPTION
This completes the implementation of adding custom auth options.
See https://github.com/cloudalchemy/ansible-grafana/pull/219 