### PR TITLE
Make sure to create default plugin provisioning directory

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,6 +12,7 @@
     - "/etc/grafana/provisioning/datasources"
     - "/etc/grafana/provisioning/dashboards"
     - "/etc/grafana/provisioning/notifiers"
+    - "/etc/grafana/provisioning/plugins"
 
 - name: Create grafana main configuration file
   template:


### PR DESCRIPTION
Ensure the default plugin provisioning directory is created to avoid getting error messages like below:

`lvl=eror msg="Failed to read plugin provisioning files from directory" logger=provisioning.plugins path=/etc/grafana/provisioning/plugins error="open /etc/grafana/provisioning/plugins: no such file or directory"`