### PR TITLE
Allow overriding grafana_package from vars

### DIFF
--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -4,7 +4,8 @@
   roles:
     - ansible-grafana
   vars:
-    grafana_version: 6.2.5
+    grafana_version: 7.1.5
+    grafana_package: grafana-enterprise
     grafana_yum_repo_template: alternative.grafana.yum.repo.j2
     grafana_security:
       admin_user: admin

--- a/molecule/alternative/templates/alternative.grafana.yum.repo.j2
+++ b/molecule/alternative/templates/alternative.grafana.yum.repo.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/oss/rpm
+baseurl=https://packages.grafana.com/enterprise/rpm
 #repo_gpgcheck=1
 enabled=1
 gpgcheck=1

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Gather variables for package dependencies
+  include_vars: debian/dependencies.yml
+
+- name: Gather variables for package dependencies
+  include_vars: debian/package.yml
+  when: grafana_package is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Gather variables for each operating system
-  include_vars: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}/main.yml"
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}/main.yml"
+    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}/main.yml"
+    - "{{ ansible_distribution | lower }}/main.yml"
+    - "{{ ansible_os_family | lower }}/main.yml"
   tags:
     - grafana_install
     - grafana_configure

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Gather variables for package dependencies
+  include_vars: redhat/dependencies.yml
+
+- name: Gather variables for package dependencies
+  include_vars: redhat/package.yml
+  when: grafana_package is not defined

--- a/tasks/suse/main.yml
+++ b/tasks/suse/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Gather variables for package dependencies
+  include_vars: suse/dependencies.yml
+
+- name: Gather variables for package dependencies
+  include_vars: suse/package.yml
+  when: grafana_package is not defined

--- a/vars/debian/dependencies.yml
+++ b/vars/debian/dependencies.yml
@@ -1,0 +1,7 @@
+---
+grafana_dependencies:
+  - apt-transport-https
+  - adduser
+  - ca-certificates
+  - libfontconfig
+  - gnupg2

--- a/vars/debian/package.yml
+++ b/vars/debian/package.yml
@@ -1,8 +1,2 @@
 ---
 grafana_package: "grafana{% if ansible_architecture == 'armv6l' %}-rpi{% endif %}{{ (grafana_version != 'latest') | ternary('=' ~ grafana_version, '') }}"
-grafana_dependencies:
-  - apt-transport-https
-  - adduser
-  - ca-certificates
-  - libfontconfig
-  - gnupg2

--- a/vars/redhat/dependencies.yml
+++ b/vars/redhat/dependencies.yml
@@ -1,5 +1,4 @@
 ---
-grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"
 # https://unix.stackexchange.com/questions/534463/cant-enable-grafana-on-boot-in-fedora-because-systemd-sysv-install-missing
 grafana_dependencies:
   - chkconfig

--- a/vars/redhat/package.yml
+++ b/vars/redhat/package.yml
@@ -1,3 +1,2 @@
 ---
 grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"
-grafana_dependencies: []

--- a/vars/suse/dependencies.yml
+++ b/vars/suse/dependencies.yml
@@ -1,0 +1,2 @@
+---
+grafana_dependencies: []

--- a/vars/suse/package.yml
+++ b/vars/suse/package.yml
@@ -1,0 +1,2 @@
+---
+grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"


### PR DESCRIPTION
Conditionally import default os-specific package names if
grafana_package isn't explicitly set.

Updates the molecule alternative tests to use the grafana-enterprise
repo to allow for also verifying that overriding grafana_package to
grafana-enterprise works.

Resolves #228

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudalchemy/ansible-grafana/235)
<!-- Reviewable:end -->
