### PR TITLE
Add more settings to datasources

### DIFF
--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -20,6 +20,7 @@
     aws_secret_key: "{{ item.aws_secret_key | default(omit) }}"
     aws_credentials_profile: "{{ item.aws_credentials_profile | default(omit) }}"
     aws_custom_metrics_namespaces: "{{ item.aws_custom_metrics_namespaces | default(omit) }}"
+    sslmode: "{{ item.sslmode | default(omit) }}"
   with_items: "{{ grafana_datasources }}"
   when: not grafana_use_provisioning
 

--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -21,6 +21,8 @@
     aws_credentials_profile: "{{ item.aws_credentials_profile | default(omit) }}"
     aws_custom_metrics_namespaces: "{{ item.aws_custom_metrics_namespaces | default(omit) }}"
     sslmode: "{{ item.sslmode | default(omit) }}"
+    additional_json_data: "{{ item.additional_json_data | default(omit) }}"
+    additional_secure_json_data: "{{ item.additional_secure_json_data | default(omit) }}"
   with_items: "{{ grafana_datasources }}"
   when: not grafana_use_provisioning
 


### PR DESCRIPTION
The community module support `sslmode` (available since at least 2.8) and now starting from ansible 2.10 it also support `additional_json_data`.
Those settings are quite useful when configuring a postgresql datasource with timescaledb extension.

Let me know if I can make this PR more clean.
Here is the documentation: https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_datasource_module.html

One can simply define a datasource like so:
```yaml
- name: "my_db"
  type: "postgres"
  sslmode: "require"
  access: "proxy"
  url: "1.2.3.4:5432"
  database: "my_db"
  user: "grafana"
  password: "grafana"
  additional_json_data:
    sslmode: require
    postgresVersion: 1300
    timescaledb: true
```

PS: it's hacktoberfest, if you don't mind could you please add `hacktoberfest-accepted` label to this PR 