### PR TITLE
Allow dashboard provisioner to create folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_snapshots` | {} | [snapshots](http://docs.grafana.org/installation/configuration/#snapshots) configuration section |
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
+| `grafana_folders_from_files_structure` | false | Should dashboard provisioner follow file directory structure and create folders |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
 | `grafana_folders_from_files_structure` | false | Should dashboard provisioner follow file directory structure and create folders |
+| `grafana_update_interval_seconds` | 60 | How often refresh dashboards provisioned from disk, in seconds |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -210,6 +210,7 @@ grafana_dashboards: []
 
 grafana_dashboards_dir: "dashboards"
 grafana_folders_from_files_structure: false
+grafana_update_interval_seconds: 60
 
 # Alert notification channels to configure
 grafana_alert_notifications: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -209,6 +209,7 @@ grafana_dashboards: []
 #    datasource: 'Prometheus'
 
 grafana_dashboards_dir: "dashboards"
+grafana_folders_from_files_structure: false
 
 # Alert notification channels to configure
 grafana_alert_notifications: []

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -120,6 +120,7 @@
              type: file
              options:
                path: "{{ grafana_data_dir }}/dashboards"
+               foldersFromFilesStructure: "{{ grafana_folders_from_files_structure }}"
         backup: false
         owner: root
         group: grafana

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -118,6 +118,7 @@
              orgId: 1
              folder: ''
              type: file
+             updateIntervalSeconds: "{{ grafana_update_interval_seconds }}"
              options:
                path: "{{ grafana_data_dir }}/dashboards"
                foldersFromFilesStructure: "{{ grafana_folders_from_files_structure }}"


### PR DESCRIPTION
This change allow dashboard provisioner to create folders following directory structure. By default it's disabled. 