### PR TITLE
Move dashboard provisioner config to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_snapshots` | {} | [snapshots](http://docs.grafana.org/installation/configuration/#snapshots) configuration section |
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
 | `grafana_dashboards` | [] | List of dashboards which should be imported |
+| `grafana_folders_from_files_structure` | false | Should dashboard provisioner follow file directory structure and create folders |
+| `grafana_update_interval_seconds` | 60 | How often refresh dashboards provisioned from disk, in seconds |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -209,6 +209,8 @@ grafana_dashboards: []
 #    datasource: 'Prometheus'
 
 grafana_dashboards_dir: "dashboards"
+grafana_folders_from_files_structure: false
+grafana_update_interval_seconds: 60
 
 # Alert notification channels to configure
 grafana_alert_notifications: []

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -109,18 +109,9 @@
   block:
     - name: Create/Update dashboards file (provisioning)
       become: true
-      copy:
-        dest: "/etc/grafana/provisioning/dashboards/ansible.yml"
-        content: |
-          apiVersion: 1
-          providers:
-           - name: 'default'
-             orgId: 1
-             folder: ''
-             type: file
-             options:
-               path: "{{ grafana_data_dir }}/dashboards"
-        backup: false
+      template:
+        src: provisioning-dashboards.yml.j2
+        dest: /etc/grafana/provisioning/dashboards/ansible.yml
         owner: root
         group: grafana
         mode: 0640

--- a/templates/provisioning-dashboards.yml.j2
+++ b/templates/provisioning-dashboards.yml.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+
+apiVersion: 1
+providers:
+ - name: dashboards
+   updateIntervalSeconds: {{ grafana_update_interval_seconds | int }}
+   options:
+     path: {{ grafana_data_dir }}/dashboards
+     foldersFromFilesStructure: {{ grafana_folders_from_files_structure }}


### PR DESCRIPTION
When variables use is needed, ansible [documentation suggest](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html#synopsis)
using template instead.

Variables with default values were removed.