### PR TITLE
more service state control

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,11 @@ grafana_port: 3000
 # Get informed by reading: http://man7.org/linux/man-pages/man7/capabilities.7.html
 grafana_cap_net_bind_service: false
 
+# Service config
+grafana_service_enabled: true
+grafana_service_state: started
+grafana_service_handler_state: restarted
+
 # External Grafana address. Variable maps to "root_url" in grafana server section
 grafana_url: "http://{{ grafana_address }}:{{ grafana_port }}"
 grafana_api_url: "{{ grafana_url }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,9 +3,10 @@
   become: true
   service:
     name: grafana-server
-    state: restarted
+    state: "{{ grafana_service_handler_state }}"
   tags:
     - grafana_run
+  when: grafana_service_state == 'started'
 
 - name: Set privileges on provisioned dashboards
   become: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -82,6 +82,6 @@
 - name: Enable and start Grafana systemd unit
   systemd:
     name: grafana-server
-    enabled: true
-    state: started
+    enabled: "{{ grafana_service_enabled }}"
+    state: "{{ grafana_service_state }}"
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,9 @@
   wait_for:
     host: "{{ grafana_address }}"
     port: "{{ grafana_port }}"
-  when: grafana_server.protocol is undefined or grafana_server.protocol in ['http', 'https']
+  when:
+    - grafana_service_state == 'started'
+    - grafana_server.protocol is undefined or grafana_server.protocol in ['http', 'https']
   tags:
     - grafana_install
     - grafana_configure
@@ -63,7 +65,9 @@
 - name: Wait for grafana to start (socket)
   wait_for:
     path: "{{ grafana_server.socket }}"
-  when: grafana_server.protocol is defined and grafana_server.protocol == 'socket'
+  when:
+    - grafana_service_state == 'started'
+    - grafana_server.protocol is defined and grafana_server.protocol == 'socket'
   tags:
     - grafana_install
     - grafana_configure
@@ -73,20 +77,26 @@
     - grafana_run
 
 - include: api_keys.yml
-  when: grafana_api_keys | length > 0
+  when:
+    - grafana_service_state == 'started'
+    - grafana_api_keys | length > 0
   tags:
     - grafana_configure
     - grafana_run
 
 - include: datasources.yml
-  when: grafana_datasources != []
+  when:
+    - grafana_service_state == 'started'
+    - grafana_datasources != []
   tags:
     - grafana_configure
     - grafana_datasources
     - grafana_run
 
 - include: notifications.yml
-  when: grafana_alert_notifications | length > 0
+  when:
+    - grafana_service_state == 'started'
+    - grafana_alert_notifications | length > 0
   tags:
     - grafana_configure
     - grafana_notifications
@@ -94,6 +104,8 @@
 
 - name: "Check if there are any dashboards in local {{ grafana_dashboards_dir }}"
   become: false
+  when:
+    - grafana_service_state == 'started'
   set_fact:
     found_dashboards: "{{ lookup('fileglob', grafana_dashboards_dir + '/*.json', wantlist=True) }}"
   tags:
@@ -102,7 +114,9 @@
     - grafana_run
 
 - include: dashboards.yml
-  when: grafana_dashboards | length > 0 or found_dashboards | length > 0
+  when:
+    - grafana_service_state == 'started'
+    - grafana_dashboards | length > 0 or found_dashboards | length > 0
   tags:
     - grafana_configure
     - grafana_dashboards


### PR DESCRIPTION
this is helpfull when:
* you do not want to enable grafana from the beginning
* you want to disable grafana on a later run
* you want more control over service starts/restarts for whatever reason