### PR TITLE
Add config parameter, to disable update checks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -141,6 +141,7 @@ grafana_session: {}
 
 grafana_analytics: {}
 #  reporting_enabled: true
+#  check_for_updates: true
 #  google_analytics_ua_id: ""
 
 # Set this for mail notifications

--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -92,6 +92,7 @@ enabled = True
 # Analytics
 [analytics]
 reporting_enabled = "{{ grafana_analytics.reporting_enabled | default(True) }}"
+check_for_updates = "{{ grafana_analytics.check_for_updates | default(True) }}"
 {% if grafana_analytics.google_analytics_ua_id is defined and grafana_analytics.google_analytics_ua_id != '' %}
 google_analytics_ua_id = "{{ grafana_analytics.google_analytics_ua_id }}"
 {% endif %}


### PR DESCRIPTION
Fixes #253 

- This PR allows disabling the default update check
- By default the update check is still performed

It is debatable if instead of using the `grafana_analytics` dict, a simple `grafana_check_for_updates` variable should be introduced.  
But since grafana is nesting the update check within analytics, it makes sense to keep it this way