### PR TITLE
Support external dashboards from custom url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_tracing` | {} | [tracing](http://docs.grafana.org/installation/configuration/#tracing) configuration section |
 | `grafana_snapshots` | {} | [snapshots](http://docs.grafana.org/installation/configuration/#snapshots) configuration section |
 | `grafana_image_storage` | {} | [image storage](http://docs.grafana.org/installation/configuration/#external-image-storage) configuration section |
-| `grafana_dashboards` | [] | List of dashboards which should be imported |
+| `grafana_dashboards` | [] | List of dashboards which should be imported from grafana.com |
+| `grafana_dashboards_external` | [] | List of dashboards which should be imported from external url |
 | `grafana_dashboards_dir` | "dashboards" | Path to a local directory containing dashboards files in `json` format |
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -208,6 +208,11 @@ grafana_dashboards: []
 #    revision_id: '1'
 #    datasource: 'Prometheus'
 
+# Dashboards from external URLs
+grafana_dashboards_external: []
+#  - url: 'https://example.com/dashboard.json'
+#    datasource: 'Prometheus'
+
 grafana_dashboards_dir: "dashboards"
 
 # Alert notification channels to configure

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -87,6 +87,9 @@
       - dashboard_id: '358'
         revision_id: '1'
         datasource: 'Prometheus'
+    grafana_dashboards_external:
+      - url: 'https://raw.githubusercontent.com/grafana/grafana/9ca12a7663d2fda709c15e18b3c381e3fccfc85e/public/app/plugins/datasource/prometheus/dashboards/grafana_stats.json'
+        datasource: 'Prometheus'
     grafana_datasources:
       - name: "Prometheus"
         type: "prometheus"

--- a/tasks/dashboards.yml
+++ b/tasks/dashboards.yml
@@ -30,6 +30,19 @@
       tags:
         - skip_ansible_lint
 
+    - name: download grafana dashboard from external url to local directory
+      get_url:
+        url: "{{ item.url }}"
+        dest: "{{ _tmp_dashboards.path }}/{{ item.url | hash('sha256') }}.json"
+      register: _download_dashboards
+      until: _download_dashboards is succeeded
+      retries: 5
+      delay: 2
+      with_items: "{{ grafana_dashboards_external }}"
+      when: grafana_dashboards_external | length > 0
+      changed_when: false
+      check_mode: false
+
     # As noted in [1] an exported dashboard replaces the exporter's datasource
     # name with a representative name, something like 'DS_GRAPHITE'. The name
     # is different for each datasource plugin, but always begins with 'DS_'.
@@ -62,7 +75,7 @@
     # This regex can be tested and understood better by looking at the
     # matches and non-matches in https://regex101.com/r/f4Gkvg/6
 
-    - name: Set the correct data source name in the dashboard
+    - name: Set the correct data source name in the dashboard (grafana.com)
       replace:
         dest: "{{ _tmp_dashboards.path }}/{{ item.dashboard_id }}.json"
         regexp: '"(?:\${)?DS_[A-Z0-9_-]+(?:})?"'
@@ -70,6 +83,16 @@
       changed_when: false
       with_items: "{{ grafana_dashboards }}"
       when: grafana_dashboards | length > 0
+
+
+    - name: Set the correct data source name in the dashboard (external)
+      replace:
+        dest: "{{ _tmp_dashboards.path }}/{{ item.url | hash('sha256') }}.json"
+        regexp: '"(?:\${)?DS_[A-Z0-9_-]+(?:})?"'
+        replace: '"{{ item.datasource }}"'
+      changed_when: false
+      with_items: "{{ grafana_dashboards_external }}"
+      when: grafana_dashboards_external | length > 0
 
 - name: Import grafana dashboards through API
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
     - grafana_run
 
 - include: dashboards.yml
-  when: grafana_dashboards | length > 0 or found_dashboards | length > 0
+  when: grafana_dashboards | length > 0 or grafana_dashboards_external | length > 0 or found_dashboards | length > 0
   tags:
     - grafana_configure
     - grafana_dashboards

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -9,7 +9,9 @@
 - name: Fail when datasources aren't configured when dashboards are set to be installed
   fail:
     msg: "You need to specify datasources for dashboards!!!"
-  when: grafana_dashboards != [] and grafana_datasources == []
+  when:
+    - grafana_dashboards != [] and grafana_datasources == [] or
+      grafana_dashboards_external != [] and grafana_datasources == []
 
 - name: Fail when grafana admin user isn't set
   fail:


### PR DESCRIPTION
With the current role it is only possible to either download from grafana.com or provide ready to use dashboards in a local directory. This patch adds support for external dashboards templates, for example directly from github.