### PR TITLE
Fix CI: Install ansible>=2.10,<2.11 dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     executor: python
     steps:
       - checkout
-      - run: pip install ansible-lint yamllint flake8
+      - run: pip install ansible-lint "ansible>=2.10,<2.11" yamllint flake8
       - run: ansible-lint
       - run: yamllint .
       - run: flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ molecule>=3.0.0
 molecule-docker
 docker
 ansible-lint>=3.4.0
+ansible>=2.10,<2.11
 testinfra>=1.7.0
 jmespath
 selinux


### PR DESCRIPTION
ansible-lint requires ansible, https://github.com/ansible-community/ansible-lint/discussions/1150
molecule requires ansible too, https://molecule.readthedocs.io/en/latest/installation.html