### PR TITLE
Avoid adding duplicates in 'auth' section

### DIFF
--- a/templates/grafana.ini.j2
+++ b/templates/grafana.ini.j2
@@ -75,7 +75,10 @@ enabled = True
 {%      for k, v in options.items() %}
 {{ k }} = {{ v }}
 {%      endfor %}
-{%    else %}
+{%    elif section != 'disable_login_form' and
+           section != 'oauth_auto_login' and 
+           section != 'disable_signout_menu' and 
+           section != 'signout_redirect_url' %}
 {{ section }} = {{ options }}
 {%    endif %}
 {%  endfor %}


### PR DESCRIPTION
## Description

If you set e.g. `signout_redirect_url` within your ansible `grafana_auth` variable, you will end up with two entries of this parameter. This happens, because it will be set inside the `[auth]` block by default:  
https://github.com/cloudalchemy/ansible-grafana/blob/f9b04329fb6416a204001255b67683e62496fc71/templates/grafana.ini.j2#L68
and during the iteration through the section loop (added with #221)
https://github.com/cloudalchemy/ansible-grafana/blob/f9b04329fb6416a204001255b67683e62496fc71/templates/grafana.ini.j2#L79

## Solution
Avoid adding _default auth_ parameters, by checking section names during the loop iteration.