### PR TITLE
Activate the LDAP authentification and local permissions

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -61,7 +61,7 @@
     msg: "You need to configure grafana_ldap.servers and grafana_ldap.group_mappings when grafana_auth.ldap is set"
   when:
     - "'ldap' in grafana_auth"
-    - grafana_ldap is not defined or ('servers' not in grafana_ldap or 'group_mappings' not in grafana_ldap)
+    - grafana_ldap is not defined or 'servers' not in grafana_ldap
 
 - name: Force grafana_use_provisioning to false if grafana_version is < 5.0 ( grafana_version is set to '{{ grafana_version }}' )
   set_fact:

--- a/templates/ldap.toml.j2
+++ b/templates/ldap.toml.j2
@@ -20,6 +20,7 @@ verbose_logging = {{ 'true' if grafana_ldap.verbose_logging else 'false' }}
 {{ k }} = {{ v | to_nice_json }}
 {% endfor %}
 
+{% if 'group_mappings' in grafana_ldap %}
 {% for org in grafana_ldap.group_mappings %}
 {%   if 'name' in org %}
 # {{ org.name }}
@@ -37,3 +38,4 @@ org_id = {{ org.id }}
 
 {%   endfor %}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Currently it's not possible to setup LDAP authentication (login/password) but to setup local permission in Grafana due to this preflight check.

`group_mappings` is only mandatory if you want to manage permission directly from LDAP.