### PR TITLE
add dependencies if install render-image plugin

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,4 +23,4 @@
   package:
     name: "{{ grafana_plugin_image_renderer_dependencies }}"
     state: present
-  when: "grafana-image-renderer in vars[grafana_plugins]"
+  when: '"grafana-image-renderer" in grafana_plugins'

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -18,3 +18,9 @@
   delay: 2
   notify:
     - restart grafana
+
+- name: Install dependencies for image-renderer plugin
+  package:
+    name: "{{ grafana_plugin_image_renderer_dependencies }}"
+    state: present
+  when: "grafana-image-renderer in vars[grafana_plugins]"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -6,3 +6,5 @@ grafana_dependencies:
   - ca-certificates
   - libfontconfig
   - gnupg2
+
+grafana_plugin_image_renderer_dependencies: []

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -3,3 +3,62 @@ grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafan
 # https://unix.stackexchange.com/questions/534463/cant-enable-grafana-on-boot-in-fedora-because-systemd-sysv-install-missing
 grafana_dependencies:
   - chkconfig
+
+grafana_plugin_image_renderer_dependencies:
+  - libXcomposite
+  - libXdamage
+  - libXtst
+  - cups
+  - libXScrnSaver
+  - pango
+  - atk
+  - adwaita-cursor-theme
+  - adwaita-icon-theme
+  - at
+  - at-spi2-atk
+  - at-spi2-core
+  - cairo-gobject
+  - colord-libs
+  - dconf
+  - desktop-file-utils
+  - ed
+  - emacs-filesystem
+  - gdk-pixbuf2
+  - glib-networking
+  - gnutls
+  - gsettings-desktop-schemas
+  - gtk-update-icon-cache
+  - gtk3
+  - hicolor-icon-theme
+  - jasper-libs
+  - json-glib
+  - libappindicator-gtk3
+  - libdbusmenu
+  - libdbusmenu-gtk3
+  - libepoxy
+  - liberation-fonts
+  - liberation-narrow-fonts
+  - liberation-sans-fonts
+  - liberation-serif-fonts
+  - libgusb
+  - libindicator-gtk3
+  - libmodman
+  - libproxy
+  - libsoup
+  - libwayland-cursor
+  - libwayland-egl
+  - libxkbcommon
+  - m4
+  - mailx
+  - nettle
+  - patch
+  - psmisc
+  - redhat-lsb-core
+  - redhat-lsb-submod-security
+  - rest
+  - spax
+  - time
+  - trousers
+  - xdg-utils
+  - xkeyboard-config
+  - alsa-lib

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -1,3 +1,4 @@
 ---
 grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"
 grafana_dependencies: []
+grafana_plugin_image_renderer_dependencies: []


### PR DESCRIPTION
Hi everyone, this is my first contribution to the project, so let me know if I do something wrong. And sorry for the English.

About the change, when there is a need to install the grafana-image-renderer plugin, it is necessary to install other operating system dependencies as well.

So that was the change, when it contains this plugin within the plugin list, it will install dependencies for RedHat distributions.

Reference: https://grafana.com/docs/grafana/latest/administration/image_rendering/#grafana-image-renderer-plugin-and-remote-rendering-service