### PR TITLE
Add Rocky Linux support

### DIFF
--- a/vars/rocky.yml
+++ b/vars/rocky.yml
@@ -1,0 +1,5 @@
+---
+grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"
+# https://unix.stackexchange.com/questions/534463/cant-enable-grafana-on-boot-in-fedora-because-systemd-sysv-install-missing
+grafana_dependencies:
+  - chkconfig


### PR DESCRIPTION
This is a workaround because Rocky Linux is not identified as RedHat until Ansible 2.11.
https://forums.rockylinux.org/t/ansible-os-family-question/3320