### PR TITLE
Loading Plugins when in proxied enviroment

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -18,3 +18,4 @@
   delay: 2
   notify:
     - restart grafana
+  environment: "{{ grafana_environment }}"


### PR DESCRIPTION
Currently, the plugins dont load when you have to go through a proxy because you are inside a corporate enviroment. So grafana fails here trying to get them directly without proxy.
Adding grafana_enviroment to the task where plugins are installed.