### PR TITLE
readme.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Datasource example:
 
 ```yaml
 grafana_datasources:
-  - name: prometheus
+  - name: Prometheus
     type: prometheus
     access: proxy
     url: 'http://{{ prometheus_web_listen_address }}'
@@ -76,7 +76,7 @@ Dashboard example:
 grafana_dashboards:
   - dashboard_id: 111
     revision_id: 1
-    datasource: prometheus
+    datasource: Prometheus
 ```
 
 Alert notification channel example:


### PR DESCRIPTION
It turns out that Grafana is case sensitive, a datasource "prometheus" is different from a datasource "Prometheus". This introduces subtle bugs if the documentation sometimes chooses lowercase "prometheus" and other times uppercase "Prometheus"  across the many var files and cloudalchemy repos (not just this one README file).