### PR TITLE
notifiers key was missing

### DIFF
--- a/tasks/notifications.yml
+++ b/tasks/notifications.yml
@@ -4,6 +4,7 @@
   copy:
     content: |
       apiVersion: 1
+      notifiers:
       {{ grafana_alert_notifications | to_nice_yaml }}
     dest: /etc/grafana/provisioning/notifiers/ansible.yml
     owner: root


### PR DESCRIPTION
Without "notifiers" in the provisioning file for notifications the grafana service could not start anymore.
Tested with Grafana v8.1.3.
Error:
"[root@<HOST> ansible]# journalctl -u grafana-server.service -f
-- Logs begin at Fri 2022-03-04 12:20:13 CET. --
Mar 30 15:30:57 <HOST> grafana-server[946630]: service init failed: Alert notification provisioning error: yaml: line 1: did not find expected key
"