### PR TITLE
New apt repository for Debian/Ubuntu

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -53,7 +53,7 @@
 
     - name: Add Grafana repository [Debian/Ubuntu]
       apt_repository:
-        repo: deb https://packages.grafana.com/oss/deb stable main
+        repo: deb https://apt.grafana.com stable main
         state: present
         update_cache: true
       register: _update_apt_cache

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,6 +8,8 @@
         update_cache: true
       when:
         - ansible_pkg_mgr == "apt"
+      retries: 5
+      delay: 2
 
     - name: Update apt cache
       apt:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,14 @@
 ---
 
 - block:
+    - name: Clean legacy Grafana repository [Debian/Ubuntu]
+      apt_repository:
+        repo: deb https://packages.grafana.com/oss/deb stable main
+        state: absent
+        update_cache: true
+      when:
+        - ansible_pkg_mgr == "apt"
+
     - name: Update apt cache
       apt:
         update_cache: true


### PR DESCRIPTION
On Nov 8th 2022, Grafana migrated deb apt server (https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/)

Now using apt.grafana.com in the install playbook. Also added a step to clean old apt repo since it’s causing error in cache update for host that re-run the role.