### PR TITLE
Allow to configure grafana packages base url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 grafana_version: latest
 grafana_yum_repo_template: etc/yum.repos.d/grafana.repo.j2
 grafana_manage_repo: true
+grafana_packages_base_url: "https://packages.grafana.com"
 
 # Should we use the provisioning capability when possible (provisioning require grafana >= 5.0)
 grafana_use_provisioning: true

--- a/molecule/alternative/templates/alternative.grafana.yum.repo.j2
+++ b/molecule/alternative/templates/alternative.grafana.yum.repo.j2
@@ -1,10 +1,10 @@
 {{ ansible_managed | comment }}
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/oss/rpm
+baseurl={{ grafana_packages_base_url }}/oss/rpm
 #repo_gpgcheck=1
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.grafana.com/gpg.key
+gpgkey={{ grafana_packages_base_url }}/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,7 +43,7 @@
 - block:
     - name: Import Grafana GPG signing key [Debian/Ubuntu]
       apt_key:
-        url: "https://packages.grafana.com/gpg.key"
+        url: "{{ grafana_packages_base_url }}/gpg.key"
         state: present
         validate_certs: false
       register: _add_apt_key
@@ -53,7 +53,7 @@
 
     - name: Add Grafana repository [Debian/Ubuntu]
       apt_repository:
-        repo: deb https://packages.grafana.com/oss/deb stable main
+        repo: "deb {{ grafana_packages_base_url }}/oss/deb stable main"
         state: present
         update_cache: true
       register: _update_apt_cache

--- a/templates/etc/yum.repos.d/grafana.repo.j2
+++ b/templates/etc/yum.repos.d/grafana.repo.j2
@@ -1,10 +1,10 @@
 {{ ansible_managed | comment }}
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/oss/rpm
+baseurl={{ grafana_packages_base_url }}/oss/rpm
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.grafana.com/gpg.key
+gpgkey={{ grafana_packages_base_url }}/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt 


### PR DESCRIPTION
This PR allows to set a custom target for grafana packages install.
It allows for example to use an artifactory generic remote.

Thx for your review.