### PR TITLE
url -> ds_url

### DIFF
--- a/tasks/datasources.yml
+++ b/tasks/datasources.yml
@@ -5,7 +5,7 @@
     grafana_user: "{{ grafana_security.admin_user }}"
     grafana_password: "{{ grafana_security.admin_password }}"
     name: "{{ item.name }}"
-    url: "{{ item.url }}"
+    ds_url: "{{ item.url }}"
     ds_type: "{{ item.type }}"
     access: "{{ item.access | default(omit) }}"
     is_default: "{{ item.isDefault | default(omit) }}"


### PR DESCRIPTION
Please look at: https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_datasource_module.html

`url` is an alias of grafana_url that is already defined in the code

`ds_url` is the datasource url

This change fixes this, because datasource declaration was not working.

Thx for review